### PR TITLE
feat(#94): Enable/Disable categories

### DIFF
--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -43,6 +43,13 @@
     "active": "Actif",
     "inactive": "Inactif"
   },
+  "categories": {
+    "status": {
+      "label": "Statut",
+      "active": "Activée",
+      "inactive": "Désactivée"
+    }
+  },
   "deliveryPriceRules": {
     "title": "Règles de prix de livraison",
     "create": "Créer une règle",

--- a/src/adapters/primary/nuxt/components/molecules/FtCategoryTree.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtCategoryTree.vue
@@ -34,6 +34,7 @@ div(v-if="isLoading")
     @selected="selected"
     @view="view"
     @update:open-items="updateOpenItems"
+    @toggle-status="toggleStatus"
   )
 </template>
 <script setup lang="ts">
@@ -105,6 +106,7 @@ const emit = defineEmits<{
   (e: 'view', uuid: string): void
   (e: 'selected', uuid: string): void
   (e: 'update:open-items', items: Array<UUID>): void
+  (e: 'toggle-status', uuid: string, currentStatus: string): void
 }>()
 
 const view = (uuid: string): void => {
@@ -113,6 +115,10 @@ const view = (uuid: string): void => {
 
 const selected = (uuid: string): void => {
   emit('selected', uuid)
+}
+
+const toggleStatus = (uuid: string, currentStatus: string): void => {
+  emit('toggle-status', uuid, currentStatus)
 }
 </script>
 

--- a/src/adapters/primary/nuxt/components/molecules/FtCategoryTreeNode.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtCategoryTreeNode.vue
@@ -7,7 +7,7 @@
       )
         .list-item(@click="toggle(item)")
           .flex.justify-between.items-center.p-2.cursor-pointer.bg-hover(
-            :class="{ 'parent-selected bg-contrast': hasSelectedChild(item) }"
+            :class="{ 'parent-selected bg-contrast': hasSelectedChild(item), 'grayscale opacity-60': item.data.status === 'INACTIVE' }"
           )
             div.flex.items-center.justify-center.space-x-4
               ft-checkbox(
@@ -20,14 +20,17 @@
               )
               img.w-8.h-8(:src="item.data.miniature")
               span {{ item.data.name }}
-            div.flex.items-center.justify-center
+            div.flex.items-center.justify-center.space-x-4
               icon.icon-md.text-link(
                 name="mdi-eye-outline"
-                @click.prevent="view(item.data.uuid)"
+                @click.stop.prevent="view(item.data.uuid)"
               ) Voir
+              ft-toggle(
+                :model-value="item.data.status === 'ACTIVE'"
+                @click.stop.prevent="toggleStatus(item.data.uuid, item.data.status)"
+              )
               span(
                 v-if="item.children.length"
-                class="ml-4"
               )
                 icon.icon-md(
                   v-if="isOpen(item.data.uuid)"
@@ -52,10 +55,12 @@
               @update:open-items="updateOpenItems"
               @selected="selected"
               @clicked.prevent="view"
+              @toggle-status="toggleStatus"
             )
 </template>
 <script setup lang="ts">
 import FtCheckbox from '@adapters/primary/nuxt/components/atoms/FtCheckbox.vue'
+import FtToggle from '@adapters/primary/nuxt/components/atoms/FtToggle.vue'
 import type {
   TreeCategoryNodeVM,
   TreeNode
@@ -114,10 +119,17 @@ const emit = defineEmits<{
   (e: 'view', uuid: string): void
   (e: 'selected', uuid: string): void
   (e: 'update:open-items', items: Array<UUID>): void
+  (e: 'toggle-status', uuid: string, currentStatus: string): void
 }>()
 
 const view = (uuid: string): void => {
   emit('view', uuid)
+}
+
+const toggleStatus = (uuid: string, currentStatus: string): void => {
+  if (!props.disabled) {
+    emit('toggle-status', uuid, currentStatus)
+  }
 }
 
 const updateOpenItems = (openItems: Array<UUID>): void => {

--- a/src/adapters/primary/nuxt/components/organisms/CategoryForm.vue
+++ b/src/adapters/primary/nuxt/components/organisms/CategoryForm.vue
@@ -40,6 +40,16 @@ div(v-if="!currentVM || currentVM.isLoading()")
     .flex.flex-row-reverse.mt-4
       .h-12.w-32.bg-gray-200.rounded.animate-pulse
 form(v-else)
+  UFormGroup.pb-4(
+    v-if="currentVM.getStatus"
+    :label="$t('categories.status.label')"
+    name="status"
+  )
+    UBadge(
+      :color="currentVM.getStatus().value === 'ACTIVE' ? 'success' : 'gray'"
+      variant="subtle"
+      size="lg"
+    ) {{ currentVM.getStatus().value === 'ACTIVE' ? $t('categories.status.active') : $t('categories.status.inactive') }}
   UFormGroup.pb-4(label="Nom" name="name")
     ft-text-field(
       :model-value="currentVM.get('name').value"

--- a/src/adapters/primary/nuxt/pages/categories/index.vue
+++ b/src/adapters/primary/nuxt/pages/categories/index.vue
@@ -8,11 +8,15 @@
     :is-loading="treeCategoriesVM.isLoading"
     :items="treeCategoriesVM.items"
     @view="categorySelected"
+    @toggle-status="handleToggleStatus"
   )
 </template>
 
 <script lang="ts" setup>
 import { getTreeCategoriesVM } from '@adapters/primary/view-models/categories/get-categories/getTreeCategoriesVM'
+import { CategoryStatus } from '@core/entities/category'
+import { disableCategory } from '@core/usecases/categories/disable-category/disableCategory'
+import { enableCategory } from '@core/usecases/categories/enable-category/enableCategory'
 import { listCategories } from '@core/usecases/categories/list-categories/listCategories'
 import { useCategoryGateway } from '../../../../../../gateways/categoryGateway'
 
@@ -29,5 +33,14 @@ const treeCategoriesVM = computed(() => {
 const categorySelected = (uuid: string) => {
   const router = useRouter()
   router.push(`/categories/get/${uuid}`)
+}
+
+const handleToggleStatus = async (uuid: string, currentStatus: string) => {
+  const categoryGateway = useCategoryGateway()
+  if (currentStatus === CategoryStatus.Active) {
+    await disableCategory(uuid, categoryGateway)
+  } else {
+    await enableCategory(uuid, categoryGateway)
+  }
 }
 </script>

--- a/src/adapters/primary/view-models/categories/category-form/categoryFormGetVM.spec.ts
+++ b/src/adapters/primary/view-models/categories/category-form/categoryFormGetVM.spec.ts
@@ -5,6 +5,7 @@ import {
 import { CategoryProductItemVM } from '@adapters/primary/view-models/categories/category-form/categoryFormVM'
 import { Header } from '@adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM'
 import { Field } from '@adapters/primary/view-models/promotions/promotion-form/promotionFormCreateVM'
+import { CategoryStatus } from '@core/entities/category'
 import { Product } from '@core/entities/product'
 import { useCategoryStore } from '@store/categoryStore'
 import { useFormStore } from '@store/formStore'
@@ -154,6 +155,27 @@ describe('Category form get VM', () => {
       it('should not allow to validate', () => {
         expect(vm.getCanValidate()).toBe(false)
       })
+    })
+  })
+  describe('Status', () => {
+    it('should return the category status as read-only when active', () => {
+      categoryStore.current = { category: minceur, products: [] }
+      vm = getVM()
+      const expectedStatusField = {
+        value: CategoryStatus.Active,
+        canEdit: false
+      }
+      expect(vm.getStatus()).toStrictEqual(expectedStatusField)
+    })
+    it('should return the category status as read-only when inactive', () => {
+      const inactiveCategory = { ...baby, status: CategoryStatus.Inactive }
+      categoryStore.current = { category: inactiveCategory, products: [] }
+      vm = getVM()
+      const expectedStatusField = {
+        value: CategoryStatus.Inactive,
+        canEdit: false
+      }
+      expect(vm.getStatus()).toStrictEqual(expectedStatusField)
     })
   })
 

--- a/src/adapters/primary/view-models/categories/category-form/categoryFormGetVM.ts
+++ b/src/adapters/primary/view-models/categories/category-form/categoryFormGetVM.ts
@@ -8,7 +8,7 @@ import {
   FormInitializer
 } from '@adapters/primary/view-models/products/product-form/productFormGetVM'
 import { Field } from '@adapters/primary/view-models/promotions/promotion-form/promotionFormCreateVM'
-import type { Category } from '@core/entities/category'
+import type { Category, CategoryStatus } from '@core/entities/category'
 import { useCategoryStore } from '@store/categoryStore'
 import { useFormStore } from '@store/formStore'
 
@@ -62,6 +62,10 @@ export class CategoryFormFieldsReader extends FormFieldsReader {
       }
     })
   }
+
+  getCurrentCategoryStatus(): CategoryStatus | undefined {
+    return this.categoryStore.current?.category?.status
+  }
 }
 
 export class CategoryFormGetVM extends CategoryFormVM {
@@ -105,6 +109,13 @@ export class CategoryFormGetVM extends CategoryFormVM {
 
   getCanValidate(): boolean {
     return false
+  }
+
+  getStatus(): Field<CategoryStatus | undefined> {
+    return {
+      value: this.fieldsReader.getCurrentCategoryStatus(),
+      canEdit: false
+    }
   }
 }
 

--- a/src/adapters/primary/view-models/categories/category-reorder-form/categoryReorderFormVM.spec.ts
+++ b/src/adapters/primary/view-models/categories/category-reorder-form/categoryReorderFormVM.spec.ts
@@ -2,6 +2,7 @@ import type {
   TreeCategoryNodeVM,
   TreeNode
 } from '@adapters/primary/view-models/categories/get-categories/getTreeCategoriesVM'
+import type { CategoryStatus } from '@core/entities/category'
 import { useCategoryStore } from '@store/categoryStore'
 import { useFormStore } from '@store/formStore'
 import { baby, dents, mum } from '@utils/testData/categories'
@@ -15,9 +16,10 @@ const createTreeNode = (
   uuid: string,
   name: string,
   miniature: string,
+  status: CategoryStatus,
   children: CategoryTree = []
 ): TreeNode<TreeCategoryNodeVM> => ({
-  data: { uuid, name, miniature },
+  data: { uuid, name, miniature, status },
   children
 })
 
@@ -45,9 +47,19 @@ describe('Category Reorder Form VM', () => {
       const vm = categoryReorderFormVM()
 
       expect(vm.tree).toStrictEqual([
-        createTreeNode(dents.uuid, dents.name, dents.miniature || ''),
-        createTreeNode(mum.uuid, mum.name, mum.miniature || '', [
-          createTreeNode(baby.uuid, baby.name, baby.miniature || '')
+        createTreeNode(
+          dents.uuid,
+          dents.name,
+          dents.miniature || '',
+          dents.status
+        ),
+        createTreeNode(mum.uuid, mum.name, mum.miniature || '', mum.status, [
+          createTreeNode(
+            baby.uuid,
+            baby.name,
+            baby.miniature || '',
+            baby.status
+          )
         ])
       ])
     })
@@ -79,8 +91,13 @@ describe('Category Reorder Form VM', () => {
 
       const vm = categoryReorderFormVM()
       const newTree = [
-        createTreeNode(mum.uuid, mum.name, mum.miniature || ''),
-        createTreeNode(dents.uuid, dents.name, dents.miniature || '')
+        createTreeNode(mum.uuid, mum.name, mum.miniature || '', mum.status),
+        createTreeNode(
+          dents.uuid,
+          dents.name,
+          dents.miniature || '',
+          dents.status
+        )
       ]
       vm.updateTree(newTree)
 
@@ -93,8 +110,13 @@ describe('Category Reorder Form VM', () => {
 
       const vm = categoryReorderFormVM()
       const newTree = [
-        createTreeNode(mum.uuid, mum.name, mum.miniature || ''),
-        createTreeNode(dents.uuid, dents.name, dents.miniature || '')
+        createTreeNode(mum.uuid, mum.name, mum.miniature || '', mum.status),
+        createTreeNode(
+          dents.uuid,
+          dents.name,
+          dents.miniature || '',
+          dents.status
+        )
       ]
       vm.updateTree(newTree)
 
@@ -107,8 +129,13 @@ describe('Category Reorder Form VM', () => {
 
       const vm = categoryReorderFormVM()
       const sameTree = [
-        createTreeNode(dents.uuid, dents.name, dents.miniature || ''),
-        createTreeNode(mum.uuid, mum.name, mum.miniature || '')
+        createTreeNode(
+          dents.uuid,
+          dents.name,
+          dents.miniature || '',
+          dents.status
+        ),
+        createTreeNode(mum.uuid, mum.name, mum.miniature || '', mum.status)
       ]
       vm.updateTree(sameTree)
 
@@ -122,13 +149,20 @@ describe('Category Reorder Form VM', () => {
       categoryStore.items = [dents, mum]
 
       const vm = categoryReorderFormVM()
-      const newTree = [createTreeNode(mum.uuid, mum.name, mum.miniature || '')]
+      const newTree = [
+        createTreeNode(mum.uuid, mum.name, mum.miniature || '', mum.status)
+      ]
       vm.updateTree(newTree)
       vm.reset()
 
       expect(vm.tree).toStrictEqual([
-        createTreeNode(dents.uuid, dents.name, dents.miniature || ''),
-        createTreeNode(mum.uuid, mum.name, mum.miniature || '')
+        createTreeNode(
+          dents.uuid,
+          dents.name,
+          dents.miniature || '',
+          dents.status
+        ),
+        createTreeNode(mum.uuid, mum.name, mum.miniature || '', mum.status)
       ])
     })
 
@@ -137,7 +171,9 @@ describe('Category Reorder Form VM', () => {
       categoryStore.items = [dents, mum]
 
       const vm = categoryReorderFormVM()
-      const newTree = [createTreeNode(mum.uuid, mum.name, mum.miniature || '')]
+      const newTree = [
+        createTreeNode(mum.uuid, mum.name, mum.miniature || '', mum.status)
+      ]
       vm.updateTree(newTree)
       vm.reset()
 

--- a/src/adapters/primary/view-models/categories/get-categories/getTreeCategoriesVM.spec.ts
+++ b/src/adapters/primary/view-models/categories/get-categories/getTreeCategoriesVM.spec.ts
@@ -2,7 +2,7 @@ import {
   getTreeCategoriesVM,
   TreeCategoriesVM
 } from '@adapters/primary/view-models/categories/get-categories/getTreeCategoriesVM'
-import { Category } from '@core/entities/category'
+import { Category, CategoryStatus } from '@core/entities/category'
 import { useCategoryStore } from '@store/categoryStore'
 import { baby, dents, minceur, mum } from '@utils/testData/categories'
 import { createPinia, setActivePinia } from 'pinia'
@@ -28,7 +28,8 @@ describe('Get tree categories VM', () => {
           data: {
             uuid: mum.uuid,
             name: mum.name,
-            miniature: mum.miniature!
+            miniature: mum.miniature!,
+            status: mum.status
           },
           children: []
         }
@@ -42,7 +43,8 @@ describe('Get tree categories VM', () => {
           data: {
             uuid: mum.uuid,
             name: mum.name,
-            miniature: mum.miniature!
+            miniature: mum.miniature!,
+            status: mum.status
           },
           children: []
         },
@@ -50,7 +52,8 @@ describe('Get tree categories VM', () => {
           data: {
             uuid: dents.uuid,
             name: dents.name,
-            miniature: dents.miniature!
+            miniature: dents.miniature!,
+            status: dents.status
           },
           children: []
         },
@@ -58,7 +61,8 @@ describe('Get tree categories VM', () => {
           data: {
             uuid: minceur.uuid,
             name: minceur.name,
-            miniature: minceur.miniature!
+            miniature: minceur.miniature!,
+            status: minceur.status
           },
           children: []
         }
@@ -75,14 +79,16 @@ describe('Get tree categories VM', () => {
           data: {
             uuid: mum.uuid,
             name: mum.name,
-            miniature: mum.miniature!
+            miniature: mum.miniature!,
+            status: mum.status
           },
           children: [
             {
               data: {
                 uuid: baby.uuid,
                 name: baby.name,
-                miniature: baby.miniature!
+                miniature: baby.miniature!,
+                status: baby.status
               },
               children: []
             }
@@ -100,7 +106,8 @@ describe('Get tree categories VM', () => {
         description: '',
         miniature: 'root-miniature-1',
         image: 'root-img-1',
-        order: 0
+        order: 0,
+        status: CategoryStatus.Active
       }
       const childCategory1: Category = {
         uuid: 'child-category1',
@@ -109,7 +116,8 @@ describe('Get tree categories VM', () => {
         parentUuid: rootCategory1.uuid,
         miniature: 'child-miniature-1',
         image: 'child-img-1',
-        order: 1
+        order: 1,
+        status: CategoryStatus.Active
       }
       const childCategory2: Category = {
         uuid: 'child-category2',
@@ -118,7 +126,8 @@ describe('Get tree categories VM', () => {
         parentUuid: rootCategory1.uuid,
         miniature: 'child-miniature-2',
         image: 'child-img-2',
-        order: 2
+        order: 2,
+        status: CategoryStatus.Inactive
       }
       const grandChildCategory1: Category = {
         uuid: 'grandChild-category1',
@@ -127,7 +136,8 @@ describe('Get tree categories VM', () => {
         parentUuid: childCategory1.uuid,
         miniature: 'grandchild-miniature-1',
         image: 'grandchild-img-1',
-        order: 3
+        order: 3,
+        status: CategoryStatus.Active
       }
       const grandChildCategory2: Category = {
         uuid: 'grandChild-category2',
@@ -136,7 +146,8 @@ describe('Get tree categories VM', () => {
         parentUuid: childCategory2.uuid,
         miniature: 'grandchild-miniature-2',
         image: 'grandchild-img-2',
-        order: 4
+        order: 4,
+        status: CategoryStatus.Inactive
       }
       const rootCategory2: Category = {
         uuid: 'root-category2',
@@ -144,7 +155,8 @@ describe('Get tree categories VM', () => {
         description: '',
         miniature: 'root-miniature-2',
         image: 'root-img-2',
-        order: 5
+        order: 5,
+        status: CategoryStatus.Active
       }
       givenExistingCategories(
         rootCategory1,
@@ -159,21 +171,24 @@ describe('Get tree categories VM', () => {
           data: {
             uuid: rootCategory1.uuid,
             name: rootCategory1.name,
-            miniature: rootCategory1.miniature!
+            miniature: rootCategory1.miniature!,
+            status: rootCategory1.status
           },
           children: [
             {
               data: {
                 uuid: childCategory1.uuid,
                 name: childCategory1.name,
-                miniature: childCategory1.miniature!
+                miniature: childCategory1.miniature!,
+                status: childCategory1.status
               },
               children: [
                 {
                   data: {
                     uuid: grandChildCategory1.uuid,
                     name: grandChildCategory1.name,
-                    miniature: grandChildCategory1.miniature!
+                    miniature: grandChildCategory1.miniature!,
+                    status: grandChildCategory1.status
                   },
                   children: []
                 }
@@ -183,14 +198,16 @@ describe('Get tree categories VM', () => {
               data: {
                 uuid: childCategory2.uuid,
                 name: childCategory2.name,
-                miniature: childCategory2.miniature!
+                miniature: childCategory2.miniature!,
+                status: childCategory2.status
               },
               children: [
                 {
                   data: {
                     uuid: grandChildCategory2.uuid,
                     name: grandChildCategory2.name,
-                    miniature: grandChildCategory2.miniature!
+                    miniature: grandChildCategory2.miniature!,
+                    status: grandChildCategory2.status
                   },
                   children: []
                 }
@@ -202,7 +219,8 @@ describe('Get tree categories VM', () => {
           data: {
             uuid: rootCategory2.uuid,
             name: rootCategory2.name,
-            miniature: rootCategory2.miniature!
+            miniature: rootCategory2.miniature!,
+            status: rootCategory2.status
           },
           children: []
         }

--- a/src/adapters/primary/view-models/categories/get-categories/getTreeCategoriesVM.ts
+++ b/src/adapters/primary/view-models/categories/get-categories/getTreeCategoriesVM.ts
@@ -1,5 +1,5 @@
-import { Category } from '@core/entities/category'
-import { UUID } from '@core/types/types'
+import type { Category, CategoryStatus } from '@core/entities/category'
+import type { UUID } from '@core/types/types'
 import { useCategoryStore } from '@store/categoryStore'
 
 export interface TreeNode<T> {
@@ -11,6 +11,7 @@ export interface TreeCategoryNodeVM {
   uuid: UUID
   name: string
   miniature: string
+  status: CategoryStatus
 }
 
 export type TreeCategoriesVM = Array<TreeNode<TreeCategoryNodeVM>>
@@ -28,7 +29,8 @@ const getChildren = (uuid: UUID): TreeCategoriesVM => {
       data: {
         uuid: c.uuid,
         name: c.name,
-        miniature: c.miniature || ''
+        miniature: c.miniature || '',
+        status: c.status
       },
       children: getChildren(c.uuid)
     }
@@ -45,7 +47,8 @@ export const getTreeCategoriesVM = (): CategoriesVM => {
         data: {
           uuid: c.uuid,
           name: c.name,
-          miniature: c.miniature || ''
+          miniature: c.miniature || '',
+          status: c.status
         },
         children: getChildren(c.uuid)
       }

--- a/src/adapters/secondary/category-gateways/InMemoryTimoutCategoryGateway.ts
+++ b/src/adapters/secondary/category-gateways/InMemoryTimoutCategoryGateway.ts
@@ -1,9 +1,9 @@
 import { InMemoryCategoryGateway } from '@adapters/secondary/category-gateways/InMemoryCategoryGateway'
-import { Category } from '@core/entities/category'
-import { UuidGenerator } from '@core/gateways/uuidGenerator'
-import { UUID } from '@core/types/types'
-import { CreateCategoryDTO } from '@core/usecases/categories/category-creation/createCategory'
-import { EditCategoryDTO } from '@core/usecases/categories/category-edition/editCategory'
+import type { Category } from '@core/entities/category'
+import type { UuidGenerator } from '@core/gateways/uuidGenerator'
+import type { UUID } from '@core/types/types'
+import type { CreateCategoryDTO } from '@core/usecases/categories/category-creation/createCategory'
+import type { EditCategoryDTO } from '@core/usecases/categories/category-edition/editCategory'
 
 export class InMemoryTimoutCategoryGateway extends InMemoryCategoryGateway {
   private readonly timeoutInMs: number
@@ -49,6 +49,22 @@ export class InMemoryTimoutCategoryGateway extends InMemoryCategoryGateway {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(super.reorder(categoryUuids))
+      }, this.timeoutInMs)
+    })
+  }
+
+  override enable(uuid: UUID): Promise<Array<Category>> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(super.enable(uuid))
+      }, this.timeoutInMs)
+    })
+  }
+
+  override disable(uuid: UUID): Promise<Array<Category>> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(super.disable(uuid))
       }, this.timeoutInMs)
     })
   }

--- a/src/adapters/secondary/category-gateways/realCategoryGateway.ts
+++ b/src/adapters/secondary/category-gateways/realCategoryGateway.ts
@@ -1,10 +1,10 @@
 import { axiosWithBearer } from '@adapters/primary/nuxt/utils/axios'
 import { RealGateway } from '@adapters/secondary/order-gateways/RealOrderGateway'
-import { Category } from '@core/entities/category'
-import { CategoryGateway } from '@core/gateways/categoryGateway'
-import { UUID } from '@core/types/types'
-import { CreateCategoryDTO } from '@core/usecases/categories/category-creation/createCategory'
-import { EditCategoryDTO } from '@core/usecases/categories/category-edition/editCategory'
+import type { Category } from '@core/entities/category'
+import type { CategoryGateway } from '@core/gateways/categoryGateway'
+import type { UUID } from '@core/types/types'
+import type { CreateCategoryDTO } from '@core/usecases/categories/category-creation/createCategory'
+import type { EditCategoryDTO } from '@core/usecases/categories/category-edition/editCategory'
 
 export class RealCategoryGateway
   extends RealGateway
@@ -69,5 +69,19 @@ export class RealCategoryGateway
       }
     )
     return res.data.items.sort((a: Category, b: Category) => a.order - b.order)
+  }
+
+  async enable(uuid: UUID): Promise<Array<Category>> {
+    const response = await axiosWithBearer.post(
+      `${this.baseUrl}/categories/${uuid}/enable`
+    )
+    return response.data.categories
+  }
+
+  async disable(uuid: UUID): Promise<Array<Category>> {
+    const response = await axiosWithBearer.post(
+      `${this.baseUrl}/categories/${uuid}/disable`
+    )
+    return response.data.categories
   }
 }

--- a/src/adapters/secondary/category-gateways/realCategoryGateway.ts
+++ b/src/adapters/secondary/category-gateways/realCategoryGateway.ts
@@ -75,13 +75,13 @@ export class RealCategoryGateway
     const response = await axiosWithBearer.post(
       `${this.baseUrl}/categories/${uuid}/enable`
     )
-    return response.data.categories
+    return response.data.categories.items
   }
 
   async disable(uuid: UUID): Promise<Array<Category>> {
     const response = await axiosWithBearer.post(
       `${this.baseUrl}/categories/${uuid}/disable`
     )
-    return response.data.categories
+    return response.data.categories.items
   }
 }

--- a/src/core/entities/category.ts
+++ b/src/core/entities/category.ts
@@ -1,6 +1,13 @@
 import { Product } from '@core/entities/product'
 import type { UUID } from '@core/types/types'
 
+export const CategoryStatus = {
+  Active: 'ACTIVE',
+  Inactive: 'INACTIVE'
+} as const
+export type CategoryStatus =
+  (typeof CategoryStatus)[keyof typeof CategoryStatus]
+
 export interface Category {
   uuid: UUID
   name: string
@@ -9,6 +16,7 @@ export interface Category {
   miniature?: string
   image?: string
   order: number
+  status: CategoryStatus
 }
 
 export interface CategoryWithProducts {
@@ -17,5 +25,11 @@ export interface CategoryWithProducts {
 }
 
 export const isCategory = (object: any): object is Category => {
-  return 'uuid' in object && 'name' in object
+  return (
+    'uuid' in object &&
+    'name' in object &&
+    'status' in object &&
+    (object.status === CategoryStatus.Active ||
+      object.status === CategoryStatus.Inactive)
+  )
 }

--- a/src/core/gateways/categoryGateway.ts
+++ b/src/core/gateways/categoryGateway.ts
@@ -1,7 +1,7 @@
-import { Category } from '@core/entities/category'
-import { UUID } from '@core/types/types'
-import { CreateCategoryDTO } from '@core/usecases/categories/category-creation/createCategory'
-import { EditCategoryDTO } from '@core/usecases/categories/category-edition/editCategory'
+import type { Category } from '@core/entities/category'
+import type { UUID } from '@core/types/types'
+import type { CreateCategoryDTO } from '@core/usecases/categories/category-creation/createCategory'
+import type { EditCategoryDTO } from '@core/usecases/categories/category-edition/editCategory'
 
 export interface CategoryGateway {
   list(): Promise<Array<Category>>
@@ -9,4 +9,6 @@ export interface CategoryGateway {
   edit(uuid: UUID, dto: EditCategoryDTO): Promise<Category>
   getByUuid(uuid: UUID): Promise<Category>
   reorder(categoryUuids: Array<UUID>): Promise<Array<Category>>
+  enable(uuid: UUID): Promise<Array<Category>>
+  disable(uuid: UUID): Promise<Array<Category>>
 }

--- a/src/core/usecases/categories/category-creation/createCategory.spec.ts
+++ b/src/core/usecases/categories/category-creation/createCategory.spec.ts
@@ -1,7 +1,7 @@
 import { InMemoryCategoryGateway } from '@adapters/secondary/category-gateways/InMemoryCategoryGateway'
 import { InMemoryProductGateway } from '@adapters/secondary/product-gateways/InMemoryProductGateway'
 import { FakeUuidGenerator } from '@adapters/secondary/uuid-generators/FakeUuidGenerator'
-import { Category } from '@core/entities/category'
+import { Category, CategoryStatus } from '@core/entities/category'
 import { Product } from '@core/entities/product'
 import { ParentCategoryDoesNotExistsError } from '@core/errors/ParentCategoryDoesNotExistsError'
 import { UUID } from '@core/types/types'
@@ -45,7 +45,8 @@ describe('Create category', () => {
       name: 'Created',
       description: 'The description',
       uuid,
-      order: 0
+      order: 0,
+      status: CategoryStatus.Active
     }
     beforeEach(async () => {
       await whenCreateCategory(uuid, categoryDTO)
@@ -71,7 +72,8 @@ describe('Create category', () => {
         name: 'Child category',
         description: 'The child description',
         uuid,
-        order: 1
+        order: 1,
+        status: CategoryStatus.Active
       }
       beforeEach(async () => {
         categoryGateway.feedWith(dents)
@@ -109,7 +111,8 @@ describe('Create category', () => {
         name: 'new-category',
         description: 'The description',
         uuid,
-        order: 0
+        order: 0,
+        status: CategoryStatus.Active
       }
       await whenCreateCategory(uuid, dto)
       expectedProducts = [

--- a/src/core/usecases/categories/category-creation/createCategory.ts
+++ b/src/core/usecases/categories/category-creation/createCategory.ts
@@ -7,7 +7,7 @@ import { useProductStore } from '@store/productStore'
 
 export type CreateCategoryDTO = Omit<
   Category,
-  'uuid' | 'image' | 'miniature' | 'order'
+  'uuid' | 'image' | 'miniature' | 'order' | 'status'
 > & {
   productsAdded: Array<UUID>
   image?: File

--- a/src/core/usecases/categories/disable-category/disableCategory.spec.ts
+++ b/src/core/usecases/categories/disable-category/disableCategory.spec.ts
@@ -1,0 +1,98 @@
+import { InMemoryCategoryGateway } from '@adapters/secondary/category-gateways/InMemoryCategoryGateway'
+import { FakeUuidGenerator } from '@adapters/secondary/uuid-generators/FakeUuidGenerator'
+import { CategoryStatus } from '@core/entities/category'
+import type { CategoryGateway } from '@core/gateways/categoryGateway'
+import { disableCategory } from '@core/usecases/categories/disable-category/disableCategory'
+import { useCategoryStore } from '@store/categoryStore'
+import { baby, dents, mum } from '@utils/testData/categories'
+import { createPinia, setActivePinia } from 'pinia'
+
+describe('Disable category', () => {
+  let categoryStore: ReturnType<typeof useCategoryStore>
+  let categoryGateway: InMemoryCategoryGateway
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    categoryStore = useCategoryStore()
+    categoryGateway = new InMemoryCategoryGateway(new FakeUuidGenerator())
+  })
+
+  describe('Disabling a single category', () => {
+    it('should call gateway disable method', async () => {
+      categoryGateway.feedWith(dents)
+      categoryStore.list([dents])
+
+      await whenDisableCategory(dents.uuid, categoryGateway)
+
+      const categories = await categoryGateway.list()
+      expect(categories[0].status).toBe(CategoryStatus.Inactive)
+    })
+  })
+
+  describe('Store update', () => {
+    it('should update store with all returned categories', async () => {
+      categoryGateway.feedWith(dents)
+      categoryStore.list([dents])
+
+      await whenDisableCategory(dents.uuid, categoryGateway)
+
+      expect(categoryStore.items[0].status).toBe(CategoryStatus.Inactive)
+    })
+  })
+
+  describe('Disabling category with descendants', () => {
+    it('should update parent category in store', async () => {
+      categoryGateway.feedWith(mum, baby)
+      categoryStore.list([mum, baby])
+
+      await whenDisableCategory(mum.uuid, categoryGateway)
+
+      expect(categoryStore.items.find((c) => c.uuid === mum.uuid)?.status).toBe(
+        CategoryStatus.Inactive
+      )
+    })
+
+    it('should update descendant categories in store', async () => {
+      categoryGateway.feedWith(mum, baby)
+      categoryStore.list([mum, baby])
+
+      await whenDisableCategory(mum.uuid, categoryGateway)
+
+      expect(
+        categoryStore.items.find((c) => c.uuid === baby.uuid)?.status
+      ).toBe(CategoryStatus.Inactive)
+    })
+  })
+
+  describe('Loading state', () => {
+    it('should set isLoading to true during operation', async () => {
+      categoryGateway.feedWith(dents)
+      categoryStore.list([dents])
+
+      const unsubscribe = categoryStore.$subscribe(
+        (mutation: unknown, state: typeof categoryStore.$state) => {
+          expect(state.isLoading).toBe(true)
+          unsubscribe()
+        }
+      )
+
+      await whenDisableCategory(dents.uuid, categoryGateway)
+    })
+
+    it('should set isLoading to false after operation completes', async () => {
+      categoryGateway.feedWith(dents)
+      categoryStore.list([dents])
+
+      await whenDisableCategory(dents.uuid, categoryGateway)
+
+      expect(categoryStore.isLoading).toBe(false)
+    })
+  })
+
+  const whenDisableCategory = async (
+    uuid: string,
+    gateway: CategoryGateway
+  ) => {
+    await disableCategory(uuid, gateway)
+  }
+})

--- a/src/core/usecases/categories/disable-category/disableCategory.ts
+++ b/src/core/usecases/categories/disable-category/disableCategory.ts
@@ -1,0 +1,17 @@
+import type { CategoryGateway } from '@core/gateways/categoryGateway'
+import type { UUID } from '@core/types/types'
+import { useCategoryStore } from '@store/categoryStore'
+
+export const disableCategory = async (
+  uuid: UUID,
+  categoryGateway: CategoryGateway
+): Promise<void> => {
+  const categoryStore = useCategoryStore()
+  categoryStore.startLoading()
+  try {
+    const updatedCategories = await categoryGateway.disable(uuid)
+    categoryStore.updateMany(updatedCategories)
+  } finally {
+    categoryStore.stopLoading()
+  }
+}

--- a/src/core/usecases/categories/enable-category/enableCategory.spec.ts
+++ b/src/core/usecases/categories/enable-category/enableCategory.spec.ts
@@ -1,0 +1,115 @@
+import { InMemoryCategoryGateway } from '@adapters/secondary/category-gateways/InMemoryCategoryGateway'
+import { FakeUuidGenerator } from '@adapters/secondary/uuid-generators/FakeUuidGenerator'
+import { CategoryStatus } from '@core/entities/category'
+import type { CategoryGateway } from '@core/gateways/categoryGateway'
+import { enableCategory } from '@core/usecases/categories/enable-category/enableCategory'
+import { useCategoryStore } from '@store/categoryStore'
+import { baby, dents, mum } from '@utils/testData/categories'
+import { createPinia, setActivePinia } from 'pinia'
+
+describe('Enable category', () => {
+  let categoryStore: ReturnType<typeof useCategoryStore>
+  let categoryGateway: InMemoryCategoryGateway
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    categoryStore = useCategoryStore()
+    categoryGateway = new InMemoryCategoryGateway(new FakeUuidGenerator())
+  })
+
+  describe('Enabling a single category', () => {
+    it('should call gateway enable method', async () => {
+      const inactiveCategory = {
+        ...dents,
+        status: CategoryStatus.Inactive
+      }
+      categoryGateway.feedWith(inactiveCategory)
+      categoryStore.list([inactiveCategory])
+
+      await whenEnableCategory(dents.uuid, categoryGateway)
+
+      const categories = await categoryGateway.list()
+      expect(categories[0].status).toBe(CategoryStatus.Active)
+    })
+  })
+
+  describe('Store update', () => {
+    it('should update store with all returned categories', async () => {
+      const inactiveCategory = {
+        ...dents,
+        status: CategoryStatus.Inactive
+      }
+      categoryGateway.feedWith(inactiveCategory)
+      categoryStore.list([inactiveCategory])
+
+      await whenEnableCategory(dents.uuid, categoryGateway)
+
+      expect(categoryStore.items[0].status).toBe(CategoryStatus.Active)
+    })
+  })
+
+  describe('Enabling category with descendants', () => {
+    it('should update all affected categories in store', async () => {
+      const inactiveMum = { ...mum, status: CategoryStatus.Inactive }
+      const inactiveBaby = { ...baby, status: CategoryStatus.Inactive }
+      categoryGateway.feedWith(inactiveMum, inactiveBaby)
+      categoryStore.list([inactiveMum, inactiveBaby])
+
+      await whenEnableCategory(mum.uuid, categoryGateway)
+
+      expect(categoryStore.items.find((c) => c.uuid === mum.uuid)?.status).toBe(
+        CategoryStatus.Active
+      )
+    })
+
+    it('should update descendant categories in store', async () => {
+      const inactiveMum = { ...mum, status: CategoryStatus.Inactive }
+      const inactiveBaby = { ...baby, status: CategoryStatus.Inactive }
+      categoryGateway.feedWith(inactiveMum, inactiveBaby)
+      categoryStore.list([inactiveMum, inactiveBaby])
+
+      await whenEnableCategory(mum.uuid, categoryGateway)
+
+      expect(
+        categoryStore.items.find((c) => c.uuid === baby.uuid)?.status
+      ).toBe(CategoryStatus.Active)
+    })
+  })
+
+  describe('Loading state', () => {
+    it('should set isLoading to true during operation', async () => {
+      const inactiveCategory = {
+        ...dents,
+        status: CategoryStatus.Inactive
+      }
+      categoryGateway.feedWith(inactiveCategory)
+      categoryStore.list([inactiveCategory])
+
+      const unsubscribe = categoryStore.$subscribe(
+        (mutation: unknown, state: typeof categoryStore.$state) => {
+          expect(state.isLoading).toBe(true)
+          unsubscribe()
+        }
+      )
+
+      await whenEnableCategory(dents.uuid, categoryGateway)
+    })
+
+    it('should set isLoading to false after operation completes', async () => {
+      const inactiveCategory = {
+        ...dents,
+        status: CategoryStatus.Inactive
+      }
+      categoryGateway.feedWith(inactiveCategory)
+      categoryStore.list([inactiveCategory])
+
+      await whenEnableCategory(dents.uuid, categoryGateway)
+
+      expect(categoryStore.isLoading).toBe(false)
+    })
+  })
+
+  const whenEnableCategory = async (uuid: string, gateway: CategoryGateway) => {
+    await enableCategory(uuid, gateway)
+  }
+})

--- a/src/core/usecases/categories/enable-category/enableCategory.ts
+++ b/src/core/usecases/categories/enable-category/enableCategory.ts
@@ -1,0 +1,17 @@
+import type { CategoryGateway } from '@core/gateways/categoryGateway'
+import type { UUID } from '@core/types/types'
+import { useCategoryStore } from '@store/categoryStore'
+
+export const enableCategory = async (
+  uuid: UUID,
+  categoryGateway: CategoryGateway
+): Promise<void> => {
+  const categoryStore = useCategoryStore()
+  categoryStore.startLoading()
+  try {
+    const updatedCategories = await categoryGateway.enable(uuid)
+    categoryStore.updateMany(updatedCategories)
+  } finally {
+    categoryStore.stopLoading()
+  }
+}

--- a/src/store/categoryStore.ts
+++ b/src/store/categoryStore.ts
@@ -1,4 +1,8 @@
-import { Category, CategoryWithProducts } from '@core/entities/category'
+import {
+  Category,
+  CategoryStatus,
+  CategoryWithProducts
+} from '@core/entities/category'
 import { Product } from '@core/entities/product'
 import { defineStore } from 'pinia'
 
@@ -32,6 +36,15 @@ export const useCategoryStore = defineStore('CategoryStore', {
         })
         .sort((a, b) => a.order - b.order)
     },
+    updateMany(categories: Array<Category>) {
+      for (const category of categories) {
+        const index = this.items.findIndex((c) => c.uuid === category.uuid)
+        if (index !== -1) {
+          this.items[index] = category
+        }
+      }
+      this.items.sort((a, b) => a.order - b.order)
+    },
     setCurrentCategory(category: Category) {
       this.current = {
         category: JSON.parse(JSON.stringify(category)),
@@ -54,7 +67,8 @@ export const useCategoryStore = defineStore('CategoryStore', {
             parentUuid: undefined,
             miniature: undefined,
             image: undefined,
-            order: 0
+            order: 0,
+            status: CategoryStatus.Active
           },
           products: []
         }

--- a/src/utils/testData/categories.ts
+++ b/src/utils/testData/categories.ts
@@ -1,4 +1,4 @@
-import { Category } from '@core/entities/category'
+import { Category, CategoryStatus } from '@core/entities/category'
 
 export const dents: Category = {
   uuid: 'category-dents',
@@ -6,7 +6,8 @@ export const dents: Category = {
   description: 'La categorie des dents',
   miniature: 'https://fakeimg.pl/50/ff0000',
   image: 'https://fakeimg.pl/300x100/ff0000',
-  order: 0
+  order: 0,
+  status: CategoryStatus.Active
 }
 
 export const mum: Category = {
@@ -15,7 +16,8 @@ export const mum: Category = {
   description: 'La categorie des mamans',
   miniature: 'https://fakeimg.pl/50/00ff00',
   image: 'https://fakeimg.pl/300x100/00ff00',
-  order: 1
+  order: 1,
+  status: CategoryStatus.Active
 }
 
 export const baby: Category = {
@@ -25,7 +27,8 @@ export const baby: Category = {
   parentUuid: mum.uuid,
   miniature: 'https://fakeimg.pl/50/0000ff',
   image: 'https://fakeimg.pl/300x100/0000ff',
-  order: 2
+  order: 2,
+  status: CategoryStatus.Active
 }
 
 export const diarrhee: Category = {
@@ -34,7 +37,8 @@ export const diarrhee: Category = {
   description: 'La categorie des diarrhées',
   miniature: 'https://fakeimg.pl/50/f0f0f0',
   image: 'https://fakeimg.pl/300x100/f0f0f0',
-  order: 3
+  order: 3,
+  status: CategoryStatus.Active
 }
 
 export const minceur: Category = {
@@ -43,5 +47,6 @@ export const minceur: Category = {
   description: 'La categorie minceur',
   miniature: 'https://fakeimg.pl/50/ffffff',
   image: 'https://fakeimg.pl/300x100/ffffff',
-  order: 4
+  order: 4,
+  status: CategoryStatus.Active
 }


### PR DESCRIPTION
## Summary
- Added toggle buttons in category list to enable/disable categories
- Implemented grayscale styling for disabled categories
- Added status indicator in category details page (read-only)
- Connected to backend enable/disable endpoints
- Updated category listing to show visual feedback for disabled state

## Related Issue
Closes #94

## Test Plan
- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual testing completed
- [x] Visual feedback verified (grayscale styling)
- [x] Toggle functionality tested (single categories and cascade)

## Screenshots
Category list with enable/disable toggles and grayscale styling for disabled categories.

---
🤖 Generated with Claude Code