### PR TITLE
feat: import promotion products from CSV (#128)

### DIFF
--- a/src/adapters/primary/nuxt/components/organisms/PromotionForm.vue
+++ b/src/adapters/primary/nuxt/components/organisms/PromotionForm.vue
@@ -79,6 +79,48 @@ div(v-if="currentVM")
             @update:model-value="endDateChanged"
             @close="close"
           )
+  div.flex.items-center.gap-4.mb-4(v-if="currentVM.get('products').canEdit")
+    ft-button.button-solid(
+      :disabled="isImporting"
+      :loading="isImporting"
+      @click="triggerFileInput"
+    )
+      icon.icon-md.mr-2(v-if="!isImporting" name="ic:baseline-upload-file")
+      | {{ isImporting ? 'Import en cours...' : 'Importer depuis CSV' }}
+    input.hidden(
+      ref="csvFileInput"
+      type="file"
+      accept=".csv"
+      @change="handleCSVImport"
+    )
+  div.flex.flex-col.gap-2.mb-4(v-if="importFeedback")
+    UAlert(
+      v-if="importFeedback.addedCount > 0"
+      :title="`${importFeedback.addedCount} produit(s) ajouté(s)`"
+      color="green"
+      :close-button="{ icon: 'i-heroicons-x-mark-20-solid' }"
+      @close="clearImportFeedback"
+    )
+    UAlert(
+      v-if="importFeedback.ineligibleCount > 0"
+      :title="`${importFeedback.ineligibleCount} produit(s) non éligible(s) aux promotions`"
+      color="orange"
+    )
+    UAlert(
+      v-if="importFeedback.notFoundCodes.length > 0"
+      :title="`${importFeedback.notFoundCodes.length} code(s) EAN13 non trouvé(s)`"
+      color="orange"
+    )
+      template(#description)
+        div.max-h-32.overflow-y-auto.text-sm.font-mono
+          | {{ importFeedback.notFoundCodes.join(', ') }}
+    UAlert(
+      v-if="importFeedback.error"
+      :title="importFeedback.error"
+      color="red"
+      :close-button="{ icon: 'i-heroicons-x-mark-20-solid' }"
+      @close="clearImportFeedback"
+    )
   ft-text-field(
     v-if="currentVM.get('products').canEdit"
     v-model="search"
@@ -134,8 +176,10 @@ div(v-if="currentVM")
 import { useSelection } from '@adapters/primary/nuxt/composables/useSelection'
 import { ReductionType } from '@core/entities/promotion'
 import { searchProducts } from '@core/usecases/product/product-searching/searchProducts'
+import { importPromotionProductsCSV } from '@core/usecases/promotions/import-promotion-products-csv/importPromotionProductsCSV'
 import { format } from 'date-fns'
 import { fr } from 'date-fns/locale'
+import { useProductGateway } from '../../../../../../gateways/productGateway'
 import { useSearchGateway } from '../../../../../../gateways/searchGateway'
 
 definePageMeta({ layout: 'main' })
@@ -155,6 +199,55 @@ const routeName = String(router.currentRoute.value.name ?? '')
 const availableProductSelector = useSelection()
 const addedProductSelector = useSelection()
 const search = ref('')
+const csvFileInput = ref<HTMLInputElement>()
+const isImporting = ref(false)
+
+interface ImportFeedback {
+  addedCount: number
+  ineligibleCount: number
+  notFoundCodes: Array<string>
+  error?: string
+}
+
+const importFeedback = ref<ImportFeedback>()
+
+const triggerFileInput = () => {
+  csvFileInput.value?.click()
+}
+
+const handleCSVImport = async (e: Event) => {
+  const target = e.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file) return
+
+  isImporting.value = true
+  try {
+    const result = await importPromotionProductsCSV(
+      file,
+      useProductGateway(),
+      (uuids) => currentVM.value.addProducts(uuids)
+    )
+    importFeedback.value = {
+      addedCount: result.addedCount,
+      ineligibleCount: result.ineligibleCount,
+      notFoundCodes: result.notFoundCodes
+    }
+  } catch {
+    importFeedback.value = {
+      addedCount: 0,
+      ineligibleCount: 0,
+      notFoundCodes: [],
+      error: "Une erreur est survenue lors de l'import"
+    }
+  } finally {
+    isImporting.value = false
+    target.value = ''
+  }
+}
+
+const clearImportFeedback = () => {
+  importFeedback.value = undefined
+}
 
 const nameChanged = (name: string) => {
   currentVM.value.set('name', name)

--- a/src/adapters/secondary/product-gateways/InMemoryProductGateway.ts
+++ b/src/adapters/secondary/product-gateways/InMemoryProductGateway.ts
@@ -1,8 +1,11 @@
 import { Category } from '@core/entities/category'
-import { Product } from '@core/entities/product'
+import { isEligibleToPromotion, Product } from '@core/entities/product'
 import { isExistingImage, type ProductImage } from '@core/entities/productImage'
 import { ProductDoesNotExistsError } from '@core/errors/ProductDoesNotExistsError'
-import { ProductGateway } from '@core/gateways/productGateway'
+import {
+  ProductGateway,
+  ResolveByEan13Result
+} from '@core/gateways/productGateway'
 import { UuidGenerator } from '@core/gateways/uuidGenerator'
 import { UUID } from '@core/types/types'
 import { CreateProductDTO } from '@core/usecases/product/product-creation/createProduct'
@@ -231,6 +234,21 @@ export class InMemoryProductGateway implements ProductGateway {
           this.products.filter((p) => productUuids.includes(p.uuid))
         )
       )
+    )
+  }
+
+  async resolveByEan13s(ean13s: Array<string>): Promise<ResolveByEan13Result> {
+    const found = this.products.filter((p) => ean13s.includes(p.ean13))
+    const foundEan13s = found.map((p) => p.ean13)
+    const notFound = ean13s.filter((e) => !foundEan13s.includes(e))
+    const eligible = found
+      .filter((p) => isEligibleToPromotion(p))
+      .map(this.toListItem)
+    const ineligibleCount = found.filter(
+      (p) => !isEligibleToPromotion(p)
+    ).length
+    return Promise.resolve(
+      JSON.parse(JSON.stringify({ eligible, ineligibleCount, notFound }))
     )
   }
 

--- a/src/adapters/secondary/product-gateways/RealProductGateway.ts
+++ b/src/adapters/secondary/product-gateways/RealProductGateway.ts
@@ -3,7 +3,10 @@ import { RealGateway } from '@adapters/secondary/order-gateways/RealOrderGateway
 import { Category } from '@core/entities/category'
 import { Product } from '@core/entities/product'
 import type { ProductImage } from '@core/entities/productImage'
-import { ProductGateway } from '@core/gateways/productGateway'
+import {
+  ProductGateway,
+  ResolveByEan13Result
+} from '@core/gateways/productGateway'
 import { UUID } from '@core/types/types'
 import { CreateProductDTO } from '@core/usecases/product/product-creation/createProduct'
 import { EditProductDTO } from '@core/usecases/product/product-edition/editProduct'
@@ -207,6 +210,19 @@ export class RealProductGateway extends RealGateway implements ProductGateway {
     newImages.forEach((img, index) => {
       formData.append(`orderedImages_files[${index}]`, img.source.file)
     })
+  }
+
+  async resolveByEan13s(ean13s: Array<string>): Promise<ResolveByEan13Result> {
+    const res = await axiosWithBearer.post(
+      `${this.baseUrl}/products/resolve-by-ean13`,
+      { ean13s },
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    return res.data
   }
 
   async create(dto: CreateProductDTO): Promise<Product> {

--- a/src/core/entities/product.ts
+++ b/src/core/entities/product.ts
@@ -53,3 +53,10 @@ export const isProduct = (object: any): object is Product => {
 export const isProductActive = (product: Product): boolean => {
   return product.status === ProductStatus.Active
 }
+
+export const isEligibleToPromotion = (product: {
+  isMedicine: boolean
+  flags: Record<string, boolean>
+}): boolean => {
+  return Boolean(product.flags.arePromotionsAllowed && !product.isMedicine)
+}

--- a/src/core/gateways/productGateway.ts
+++ b/src/core/gateways/productGateway.ts
@@ -3,7 +3,13 @@ import { UUID } from '@core/types/types'
 import { CreateProductDTO } from '@core/usecases/product/product-creation/createProduct'
 import { EditProductDTO } from '@core/usecases/product/product-edition/editProduct'
 import { ProductListItem } from '@core/usecases/product/product-listing/productListItem'
-import { Product } from '../entities/product'
+import type { Product } from '../entities/product'
+
+export interface ResolveByEan13Result {
+  eligible: Array<ProductListItem>
+  ineligibleCount: number
+  notFound: Array<string>
+}
 
 export interface ProductGateway {
   list(limit: number, offset: number): Promise<Array<ProductListItem>>
@@ -27,4 +33,5 @@ export interface ProductGateway {
     category: Category,
     productUuids: Array<UUID>
   ): Promise<Array<Product>>
+  resolveByEan13s(ean13s: Array<string>): Promise<ResolveByEan13Result>
 }

--- a/src/core/usecases/product/product-creation/inMemoryFailProductGateway.ts
+++ b/src/core/usecases/product/product-creation/inMemoryFailProductGateway.ts
@@ -1,6 +1,9 @@
 import { Category } from '@core/entities/category'
 import { Product } from '@core/entities/product'
-import { ProductGateway } from '@core/gateways/productGateway'
+import type {
+  ProductGateway,
+  ResolveByEan13Result
+} from '@core/gateways/productGateway'
 import { UUID } from '@core/types/types'
 import { EditProductDTO } from '../product-edition/editProduct'
 import { ProductListItem } from '../product-listing/productListItem'
@@ -62,6 +65,10 @@ export class InMemoryFailProductGateway implements ProductGateway {
     category: Category,
     productUuids: Array<UUID>
   ): Promise<Array<Product>> {
+    throw new Error(this.errorMessage)
+  }
+
+  resolveByEan13s(ean13s: Array<string>): Promise<ResolveByEan13Result> {
     throw new Error(this.errorMessage)
   }
 

--- a/src/core/usecases/promotions/import-promotion-products-csv/importPromotionProductsCSV.spec.ts
+++ b/src/core/usecases/promotions/import-promotion-products-csv/importPromotionProductsCSV.spec.ts
@@ -1,0 +1,112 @@
+import { InMemoryProductGateway } from '@adapters/secondary/product-gateways/InMemoryProductGateway'
+import { FakeUuidGenerator } from '@adapters/secondary/uuid-generators/FakeUuidGenerator'
+import {
+  ImportResult,
+  importPromotionProductsCSV
+} from '@core/usecases/promotions/import-promotion-products-csv/importPromotionProductsCSV'
+import { useProductStore } from '@store/productStore'
+import {
+  anaca3Minceur,
+  calmosine,
+  dolodent,
+  productWithForbiddenPromotion
+} from '@utils/testData/products'
+import { createPinia, setActivePinia } from 'pinia'
+
+describe('Import promotion products CSV', () => {
+  let productGateway: InMemoryProductGateway
+  let productStore: ReturnType<typeof useProductStore>
+  let result: ImportResult
+  let addedUuids: Array<string>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    productGateway = new InMemoryProductGateway(new FakeUuidGenerator())
+    productStore = useProductStore()
+    addedUuids = []
+  })
+
+  const addProducts = (uuids: Array<string>) => {
+    addedUuids = uuids
+  }
+
+  describe('CSV with eligible products', () => {
+    beforeEach(async () => {
+      productGateway.feedWith(anaca3Minceur, calmosine)
+      await whenImporting(
+        `Code13;Name\n${anaca3Minceur.ean13};Anaca3\n${calmosine.ean13};Calmosine`
+      )
+    })
+
+    it('should add eligible products to product store', () => {
+      expect(productStore.getByUuid(anaca3Minceur.uuid)).toBeDefined()
+    })
+
+    it('should return correct added count', () => {
+      expect(result.addedCount).toStrictEqual(2)
+    })
+
+    it('should call addProducts with eligible uuids', () => {
+      expect(addedUuids).toStrictEqual([anaca3Minceur.uuid, calmosine.uuid])
+    })
+  })
+
+  describe('CSV with medicine products', () => {
+    beforeEach(async () => {
+      productGateway.feedWith(dolodent, anaca3Minceur)
+      await whenImporting(`Code13\n${dolodent.ean13}\n${anaca3Minceur.ean13}`)
+    })
+
+    it('should return ineligible count', () => {
+      expect(result.ineligibleCount).toStrictEqual(1)
+    })
+  })
+
+  describe('CSV with products that have promotions forbidden', () => {
+    beforeEach(async () => {
+      productGateway.feedWith(productWithForbiddenPromotion, anaca3Minceur)
+      await whenImporting(
+        `Code13\n${productWithForbiddenPromotion.ean13}\n${anaca3Minceur.ean13}`
+      )
+    })
+
+    it('should return ineligible count', () => {
+      expect(result.ineligibleCount).toStrictEqual(1)
+    })
+  })
+
+  describe('CSV with unknown EAN13 codes', () => {
+    beforeEach(async () => {
+      productGateway.feedWith(anaca3Minceur)
+      await whenImporting(`Code13\n${anaca3Minceur.ean13}\n9999999999999`)
+    })
+
+    it('should return not found codes', () => {
+      expect(result.notFoundCodes).toStrictEqual(['9999999999999'])
+    })
+  })
+
+  describe('Empty CSV (header only)', () => {
+    beforeEach(async () => {
+      productGateway.feedWith(anaca3Minceur)
+      await whenImporting('Code13')
+    })
+
+    it('should return empty result', () => {
+      expect(result).toStrictEqual({
+        addedCount: 0,
+        ineligibleCount: 0,
+        notFoundCodes: []
+      })
+    })
+
+    it('should not call addProducts', () => {
+      expect(addedUuids).toStrictEqual([])
+    })
+  })
+
+  const whenImporting = async (csvContent: string) => {
+    const file = new File([csvContent], 'products.csv', { type: 'text/csv' })
+    result = await importPromotionProductsCSV(file, productGateway, addProducts)
+  }
+})

--- a/src/core/usecases/promotions/import-promotion-products-csv/importPromotionProductsCSV.ts
+++ b/src/core/usecases/promotions/import-promotion-products-csv/importPromotionProductsCSV.ts
@@ -1,0 +1,36 @@
+import type { ProductGateway } from '@core/gateways/productGateway'
+import { useProductStore } from '@store/productStore'
+import { readFileAsText } from '@utils/file'
+import { parsePromotionCSV } from './parsePromotionCSV'
+
+export interface ImportResult {
+  addedCount: number
+  ineligibleCount: number
+  notFoundCodes: Array<string>
+}
+
+export const importPromotionProductsCSV = async (
+  file: File,
+  productGateway: ProductGateway,
+  addProducts: (uuids: Array<string>) => void
+): Promise<ImportResult> => {
+  const productStore = useProductStore()
+
+  const csvContent = await readFileAsText(file)
+  const ean13s = parsePromotionCSV(csvContent)
+
+  if (ean13s.length === 0) {
+    return { addedCount: 0, ineligibleCount: 0, notFoundCodes: [] }
+  }
+
+  const result = await productGateway.resolveByEan13s(ean13s)
+
+  productStore.list(result.eligible)
+  addProducts(result.eligible.map((p) => p.uuid))
+
+  return {
+    addedCount: result.eligible.length,
+    ineligibleCount: result.ineligibleCount,
+    notFoundCodes: result.notFound
+  }
+}

--- a/src/core/usecases/promotions/import-promotion-products-csv/parsePromotionCSV.spec.ts
+++ b/src/core/usecases/promotions/import-promotion-products-csv/parsePromotionCSV.spec.ts
@@ -1,0 +1,53 @@
+import { parsePromotionCSV } from './parsePromotionCSV'
+
+describe('Parse promotion CSV', () => {
+  it('should parse semicolon-delimited CSV with header', () => {
+    const csv = 'Code13;Name\n3401234567890;Produit A'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['3401234567890'])
+  })
+
+  it('should parse comma-delimited CSV', () => {
+    const csv = 'Code13,Name\n3401234567890,Produit A'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['3401234567890'])
+  })
+
+  it('should handle quoted values', () => {
+    const csv = 'Code13;Name\n"3401234567890";"Produit A"'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['3401234567890'])
+  })
+
+  it('should trim whitespace', () => {
+    const csv = 'Code13;Name\n  3401234567890  ;Produit A'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['3401234567890'])
+  })
+
+  it('should skip empty lines', () => {
+    const csv = 'Code13\n\n3401234567890\n\n'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['3401234567890'])
+  })
+
+  it('should deduplicate EAN13 codes', () => {
+    const csv = 'Code13\n3401234567890\n3401234567890'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['3401234567890'])
+  })
+
+  it('should handle short codes (7 digits)', () => {
+    const csv = 'Code13\n1234567'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['1234567'])
+  })
+
+  it('should skip non-numeric values', () => {
+    const csv = 'Code13\nabc\n1234567890123'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['1234567890123'])
+  })
+
+  it('should handle BOM character', () => {
+    const csv = '\uFEFFCode13\n3401234567890'
+    expect(parsePromotionCSV(csv)).toStrictEqual(['3401234567890'])
+  })
+
+  it('should return empty array for header-only CSV', () => {
+    const csv = 'Code13'
+    expect(parsePromotionCSV(csv)).toStrictEqual([])
+  })
+})

--- a/src/core/usecases/promotions/import-promotion-products-csv/parsePromotionCSV.ts
+++ b/src/core/usecases/promotions/import-promotion-products-csv/parsePromotionCSV.ts
@@ -1,0 +1,15 @@
+export const parsePromotionCSV = (csvContent: string): Array<string> => {
+  const content = csvContent.replace(/^\uFEFF/, '')
+  const lines = content.split(/\r?\n/)
+  const dataLines = lines.slice(1)
+  const ean13s: Array<string> = []
+
+  for (const line of dataLines) {
+    const value = line.split(/[;,]/)[0]?.replace(/"/g, '').trim()
+    if (value && /^\d+$/.test(value)) {
+      ean13s.push(value)
+    }
+  }
+
+  return [...new Set(ean13s)]
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,4 +1,4 @@
-export const getFileContent = (file: File): Promise<string> => {
+const readFile = (file: File, mode: 'text' | 'dataUrl'): Promise<string> => {
   const reader = new FileReader()
   return new Promise<string>((resolve, reject) => {
     reader.onload = (e: ProgressEvent<FileReader>) => {
@@ -14,6 +14,11 @@ export const getFileContent = (file: File): Promise<string> => {
       reject(new Error('Error reading file'))
     }
 
-    reader.readAsDataURL(file)
+    if (mode === 'text') reader.readAsText(file)
+    else reader.readAsDataURL(file)
   })
 }
+
+export const readFileAsText = (file: File) => readFile(file, 'text')
+
+export const getFileContent = (file: File) => readFile(file, 'dataUrl')


### PR DESCRIPTION
## Summary
- Add CSV import button on promotion form (create + edit) with loading state
- Parse CSV (semicolons/commas, quoted values, BOM, dedup) and resolve EAN13 codes via backend
- Show categorized feedback: green for added, orange for ineligible/not-found with scrollable code list
- Uses `isEligibleToPromotion` shared function, no manual Product→ProductListItem mapping

## Test plan
- [ ] Frontend unit tests pass (`TZ=UTC pnpm test run`)
- [ ] Type check passes (`pnpm vue-tsc --noEmit`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Import CSV on promotion create page — verify products added, feedback shown
- [ ] Import CSV with medicines — verify they are excluded with count
- [ ] Import CSV with unknown codes — verify scrollable list shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)