### PR TITLE
feat: add CA HT card, tax-rate pie chart, fix KPI overflow (#129)

### DIFF
--- a/gateways/dashBoardGateway.ts
+++ b/gateways/dashBoardGateway.ts
@@ -52,6 +52,7 @@ gateway.feedWith({
   totalSales: {
     count: 550,
     turnover: 2750000,
+    turnoverHT: 2400000,
     averageBasketValue: 5000,
     canceledTurnover: 0,
     deliveryPrice: 0
@@ -59,6 +60,7 @@ gateway.feedWith({
   previousYearTotalSales: {
     count: 1000,
     turnover: 4500000,
+    turnoverHT: 3900000,
     averageBasketValue: 4500,
     canceledTurnover: 0,
     deliveryPrice: 0
@@ -169,7 +171,14 @@ gateway.feedWith({
       subscribers: 680,
       nonSubscribers: 570
     }
-  }
+  },
+  revenueByTaxRate: [
+    { percentTaxRate: 2.1, revenueTTC: 450000, kind: 'PRODUCT' },
+    { percentTaxRate: 5.5, revenueTTC: 950000, kind: 'PRODUCT' },
+    { percentTaxRate: 10, revenueTTC: 650000, kind: 'PRODUCT' },
+    { percentTaxRate: 20, revenueTTC: 700000, kind: 'PRODUCT' },
+    { percentTaxRate: 20, revenueTTC: 120000, kind: 'DELIVERY' }
+  ]
 })
 
 export const useDashboardGateway = (): DashboardGateway => {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -105,6 +105,14 @@
     "orders": "commandes",
     "totalTurnover": "Chiffre d'affaires total",
     "revenue": "de revenus",
+    "totalTurnoverHT": "Chiffre d'affaires HT",
+    "revenueHT": "de revenus HT",
+    "turnoverByTaxRate": {
+      "title": "CA TTC par taux de TVA",
+      "productLabel": "Produit {rate}%",
+      "deliveryLabel": "Livraison {rate}%",
+      "tooltip": "CA TTC (€)"
+    },
     "canceledTurnover": "Chiffre d'affaires annulé",
     "canceledRevenue": "de revenus annulés",
     "deliveryPrice": "Frais de livraison",

--- a/src/adapters/primary/nuxt/components/molecules/TurnoverByTaxRatePieChart.vue
+++ b/src/adapters/primary/nuxt/components/molecules/TurnoverByTaxRatePieChart.vue
@@ -1,0 +1,37 @@
+<template lang="pug">
+div
+  PieChart(:data="chartData" :config="pieChartConfig")
+</template>
+
+<script setup lang="ts">
+import type { RevenueByTaxRateVM } from '@adapters/primary/view-models/dashboard/get-dashboard/getDashboardVM'
+import PieChart from './PieChart.vue'
+
+const props = defineProps<{
+  data: RevenueByTaxRateVM[]
+}>()
+
+const { t } = useI18n()
+
+const chartData = computed(() =>
+  props.data.map((entry: RevenueByTaxRateVM) => {
+    const labelKey =
+      entry.kind === 'DELIVERY'
+        ? 'dashboard.turnoverByTaxRate.deliveryLabel'
+        : 'dashboard.turnoverByTaxRate.productLabel'
+    return {
+      id: `${entry.kind.toLowerCase()}-${entry.percentTaxRate}`,
+      label: t(labelKey, { rate: entry.percentTaxRate }),
+      revenueTTC: Math.round(entry.revenueTTC * 100) / 100
+    }
+  })
+)
+
+const pieChartConfig = {
+  idField: 'id',
+  nameField: 'label',
+  countField: 'revenueTTC',
+  innerRadius: 0.5,
+  tooltipLabel: t('dashboard.turnoverByTaxRate.tooltip')
+}
+</script>

--- a/src/adapters/primary/nuxt/pages/dashboard/index.vue
+++ b/src/adapters/primary/nuxt/pages/dashboard/index.vue
@@ -117,22 +117,19 @@ div(v-if="permissions.canAccessDashboard")
   .flex.justify-center.items-center.h-64(v-if="isLoading")
     icon.animate-spin.h-8.w-8(name="i-heroicons-arrow-path")
   .dashboard-content(v-else)
-    .grid.grid-cols-1.gap-4.mb-8(class="md:grid-cols-5")
+    .grid.grid-cols-1.gap-4.mb-8(class="md:grid-cols-2 lg:grid-cols-3")
       UCard(v-for="(stat, index) in statsCards" :key="index")
         template(#header)
           .text-center
             h3.text-lg.font-medium {{ stat.title }}
         template(#default)
-          .flex.justify-center.gap-6(v-if="stat.showDualYear")
-            .text-center
-              p.text-xs.text-gray-500.mb-1.font-medium {{ previousYear }}
-              p.text-xl.font-bold {{ stat.isApplicableWithProductFilters ? stat.previousYearValue : areProductFiltersApplied ? 'N/A' : stat.previousYearValue }}
-            .border-l.border-gray-200
-            .text-center
-              p.text-xs.text-gray-500.mb-1.font-medium {{ currentYear }}
-              p.text-xl.font-bold {{ stat.isApplicableWithProductFilters ? stat.value : areProductFiltersApplied ? 'N/A' : stat.value }}
+          .text-center(v-if="stat.showDualYear")
+            p.font-bold.tabular-nums.whitespace-nowrap(class="text-2xl") {{ stat.isApplicableWithProductFilters ? stat.value : areProductFiltersApplied ? 'N/A' : stat.value }}
+            p.text-xs.text-gray-500.mt-1.tabular-nums.whitespace-nowrap
+              | {{ previousYear }}:&nbsp;
+              span.font-medium {{ stat.isApplicableWithProductFilters ? stat.previousYearValue : areProductFiltersApplied ? 'N/A' : stat.previousYearValue }}
           .text-center(v-else)
-            p.text-2xl.font-bold {{ stat.isApplicableWithProductFilters ? stat.value : areProductFiltersApplied ? 'N/A' : stat.value }}
+            p.font-bold.tabular-nums.whitespace-nowrap(class="text-2xl") {{ stat.isApplicableWithProductFilters ? stat.value : areProductFiltersApplied ? 'N/A' : stat.value }}
           p.text-sm.text-gray-500.text-center.mt-2 {{ stat.description }}
 
     .grid.grid-cols-1.gap-6.mb-8(class="lg:grid-cols-2")
@@ -194,6 +191,12 @@ div(v-if="permissions.canAccessDashboard")
         template(#default)
           .h-80
             MonthlyCanceledTurnoverChart(:data="dashboard.previousYearMonthlySales" :next-year-data="dashboard.monthlySales")
+      UCard
+        template(#header)
+          h3.text-lg.font-medium {{ $t('dashboard.turnoverByTaxRate.title') }}
+        template(#default)
+          .h-80
+            TurnoverByTaxRatePieChart(:data="dashboard.revenueByTaxRate")
 
     h3.text-lg.font-bold.text-primary-700.mb-4.mt-8(v-if="!areProductFiltersApplied") {{ $t('dashboard.userStatistics.title') }}
     .grid.grid-cols-1.gap-4.mb-8(v-if="!areProductFiltersApplied" class="md:grid-cols-3")
@@ -360,6 +363,16 @@ const statsCards = computed(() => [
       dashboard.value.previousYearTotalSales.turnover
     ),
     description: t('dashboard.revenue'),
+    isApplicableWithProductFilters: true,
+    showDualYear: true
+  },
+  {
+    title: t('dashboard.totalTurnoverHT'),
+    value: formatCurrency(dashboard.value.totalSales.turnoverHT),
+    previousYearValue: formatCurrency(
+      dashboard.value.previousYearTotalSales.turnoverHT
+    ),
+    description: t('dashboard.revenueHT'),
     isApplicableWithProductFilters: true,
     showDualYear: true
   },

--- a/src/adapters/primary/view-models/dashboard/get-dashboard/getDashboardVM.spec.ts
+++ b/src/adapters/primary/view-models/dashboard/get-dashboard/getDashboardVM.spec.ts
@@ -57,6 +57,7 @@ describe('getDashboardVM', () => {
       totalSales: {
         count: 370,
         turnover: 3250000,
+        turnoverHT: 2800000,
         canceledTurnover: 49000,
         averageBasketValue: 8784,
         deliveryPrice: 27000
@@ -64,6 +65,7 @@ describe('getDashboardVM', () => {
       previousYearTotalSales: {
         count: 350,
         turnover: 3050000,
+        turnoverHT: 2600000,
         canceledTurnover: 45000,
         averageBasketValue: 8714,
         deliveryPrice: 25000
@@ -124,7 +126,12 @@ describe('getDashboardVM', () => {
           subscribers: 680,
           nonSubscribers: 570
         }
-      }
+      },
+      revenueByTaxRate: [
+        { percentTaxRate: 2.1, revenueTTC: 500000, kind: 'PRODUCT' },
+        { percentTaxRate: 20, revenueTTC: 1200000, kind: 'PRODUCT' },
+        { percentTaxRate: 20, revenueTTC: 80000, kind: 'DELIVERY' }
+      ]
     }
 
     statsStore.dashboard = mockDashboard
@@ -147,6 +154,7 @@ describe('getDashboardVM', () => {
       totalSales: {
         count: mockDashboard.totalSales.count,
         turnover: mockDashboard.totalSales.turnover / 100,
+        turnoverHT: mockDashboard.totalSales.turnoverHT / 100,
         canceledTurnover: mockDashboard.totalSales.canceledTurnover / 100,
         averageBasketValue: mockDashboard.totalSales.averageBasketValue / 100,
         deliveryPrice: mockDashboard.totalSales.deliveryPrice / 100
@@ -154,6 +162,7 @@ describe('getDashboardVM', () => {
       previousYearTotalSales: {
         count: mockDashboard.previousYearTotalSales.count,
         turnover: mockDashboard.previousYearTotalSales.turnover / 100,
+        turnoverHT: mockDashboard.previousYearTotalSales.turnoverHT / 100,
         canceledTurnover:
           mockDashboard.previousYearTotalSales.canceledTurnover / 100,
         averageBasketValue:
@@ -165,7 +174,12 @@ describe('getDashboardVM', () => {
       ordersByLaboratory: mockDashboard.ordersByLaboratory,
       productQuantitiesByCategory: mockDashboard.productQuantitiesByCategory,
       productStockStats: mockDashboard.productStockStats,
-      userStatistics: mockDashboard.userStatistics
+      userStatistics: mockDashboard.userStatistics,
+      revenueByTaxRate: mockDashboard.revenueByTaxRate.map((entry) => ({
+        percentTaxRate: entry.percentTaxRate,
+        revenueTTC: entry.revenueTTC / 100,
+        kind: entry.kind
+      }))
     })
   })
 
@@ -178,6 +192,7 @@ describe('getDashboardVM', () => {
       totalSales: {
         count: 0,
         turnover: 0,
+        turnoverHT: 0,
         canceledTurnover: 0,
         averageBasketValue: 0,
         deliveryPrice: 0
@@ -185,6 +200,7 @@ describe('getDashboardVM', () => {
       previousYearTotalSales: {
         count: 0,
         turnover: 0,
+        turnoverHT: 0,
         canceledTurnover: 0,
         averageBasketValue: 0,
         deliveryPrice: 0
@@ -206,7 +222,8 @@ describe('getDashboardVM', () => {
           subscribers: 0,
           nonSubscribers: 0
         }
-      }
+      },
+      revenueByTaxRate: []
     })
   })
 })

--- a/src/adapters/primary/view-models/dashboard/get-dashboard/getDashboardVM.ts
+++ b/src/adapters/primary/view-models/dashboard/get-dashboard/getDashboardVM.ts
@@ -4,6 +4,8 @@ import type {
   OrderByLaboratory,
   ProductByCategory,
   ProductStockStats,
+  RevenueByTaxRate,
+  RevenueByTaxRateKind,
   TopProduct,
   TotalSales,
   UserStatistics
@@ -34,12 +36,23 @@ export interface MonthlySalesVM
 export interface TotalSalesVM
   extends Omit<
     TotalSales,
-    'turnover' | 'canceledTurnover' | 'deliveryPrice' | 'averageBasketValue'
+    | 'turnover'
+    | 'turnoverHT'
+    | 'canceledTurnover'
+    | 'deliveryPrice'
+    | 'averageBasketValue'
   > {
   turnover: number
+  turnoverHT: number
   canceledTurnover: number
   deliveryPrice: number
   averageBasketValue: number
+}
+
+export interface RevenueByTaxRateVM {
+  percentTaxRate: number
+  revenueTTC: number
+  kind: RevenueByTaxRateKind
 }
 
 export interface DashboardVM {
@@ -53,6 +66,7 @@ export interface DashboardVM {
   productQuantitiesByCategory: ProductByCategory[]
   productStockStats: ProductStockStats
   userStatistics: UserStatistics
+  revenueByTaxRate: RevenueByTaxRateVM[]
 }
 
 export const getDashboardVM = (): DashboardVM => {
@@ -65,6 +79,7 @@ export const getDashboardVM = (): DashboardVM => {
       totalSales: {
         count: 0,
         turnover: 0,
+        turnoverHT: 0,
         canceledTurnover: 0,
         deliveryPrice: 0,
         averageBasketValue: 0
@@ -72,6 +87,7 @@ export const getDashboardVM = (): DashboardVM => {
       previousYearTotalSales: {
         count: 0,
         turnover: 0,
+        turnoverHT: 0,
         canceledTurnover: 0,
         deliveryPrice: 0,
         averageBasketValue: 0
@@ -93,7 +109,8 @@ export const getDashboardVM = (): DashboardVM => {
           subscribers: 0,
           nonSubscribers: 0
         }
-      }
+      },
+      revenueByTaxRate: []
     }
   }
 
@@ -112,6 +129,7 @@ export const getDashboardVM = (): DashboardVM => {
     totalSales: {
       ...dashboard.totalSales,
       turnover: dashboard.totalSales.turnover / 100,
+      turnoverHT: dashboard.totalSales.turnoverHT / 100,
       canceledTurnover: dashboard.totalSales.canceledTurnover / 100,
       deliveryPrice: dashboard.totalSales.deliveryPrice / 100,
       averageBasketValue: dashboard.totalSales.averageBasketValue / 100
@@ -119,6 +137,7 @@ export const getDashboardVM = (): DashboardVM => {
     previousYearTotalSales: {
       ...dashboard.previousYearTotalSales,
       turnover: dashboard.previousYearTotalSales.turnover / 100,
+      turnoverHT: dashboard.previousYearTotalSales.turnoverHT / 100,
       canceledTurnover: dashboard.previousYearTotalSales.canceledTurnover / 100,
       deliveryPrice: dashboard.previousYearTotalSales.deliveryPrice / 100,
       averageBasketValue:
@@ -129,6 +148,11 @@ export const getDashboardVM = (): DashboardVM => {
     ordersByLaboratory: dashboard.ordersByLaboratory,
     productQuantitiesByCategory: dashboard.productQuantitiesByCategory,
     productStockStats: dashboard.productStockStats,
-    userStatistics: dashboard.userStatistics
+    userStatistics: dashboard.userStatistics,
+    revenueByTaxRate: dashboard.revenueByTaxRate.map((entry) => ({
+      percentTaxRate: entry.percentTaxRate,
+      revenueTTC: entry.revenueTTC / 100,
+      kind: entry.kind
+    }))
   }
 }

--- a/src/core/entities/dashboard.ts
+++ b/src/core/entities/dashboard.ts
@@ -35,9 +35,18 @@ export interface MonthlySales {
 export interface TotalSales {
   count: number
   turnover: number
+  turnoverHT: number
   canceledTurnover: number
   deliveryPrice: number
   averageBasketValue: number
+}
+
+export type RevenueByTaxRateKind = 'PRODUCT' | 'DELIVERY'
+
+export interface RevenueByTaxRate {
+  percentTaxRate: number
+  revenueTTC: number
+  kind: RevenueByTaxRateKind
 }
 
 export interface TopProductCategory {
@@ -89,4 +98,5 @@ export interface Dashboard {
   productQuantitiesByCategory: ProductByCategory[]
   productStockStats: ProductStockStats
   userStatistics: UserStatistics
+  revenueByTaxRate: RevenueByTaxRate[]
 }

--- a/src/core/usecases/dashboard/get-dashboard/getDashboard.spec.ts
+++ b/src/core/usecases/dashboard/get-dashboard/getDashboard.spec.ts
@@ -64,6 +64,7 @@ describe('GetDashboard', () => {
       totalSales: {
         count: 550,
         turnover: 2750000,
+        turnoverHT: 2400000,
         averageBasketValue: 5000,
         canceledTurnover: 0,
         deliveryPrice: 0
@@ -71,6 +72,7 @@ describe('GetDashboard', () => {
       previousYearTotalSales: {
         count: 1000,
         turnover: 4500000,
+        turnoverHT: 3900000,
         averageBasketValue: 4500,
         canceledTurnover: 0,
         deliveryPrice: 0
@@ -193,7 +195,13 @@ describe('GetDashboard', () => {
           subscribers: 680,
           nonSubscribers: 570
         }
-      }
+      },
+      revenueByTaxRate: [
+        { percentTaxRate: 2.1, revenueTTC: 450000, kind: 'PRODUCT' },
+        { percentTaxRate: 5.5, revenueTTC: 950000, kind: 'PRODUCT' },
+        { percentTaxRate: 20, revenueTTC: 1350000, kind: 'PRODUCT' },
+        { percentTaxRate: 20, revenueTTC: 80000, kind: 'DELIVERY' }
+      ]
     }
     dashboardGateway.feedWith(mockData)
   })
@@ -232,7 +240,8 @@ describe('GetDashboard', () => {
       ordersByLaboratory: mockData.ordersByLaboratory,
       productQuantitiesByCategory: mockData.productQuantitiesByCategory,
       productStockStats: mockData.productStockStats,
-      userStatistics: mockData.userStatistics
+      userStatistics: mockData.userStatistics,
+      revenueByTaxRate: mockData.revenueByTaxRate
     })
   })
 
@@ -248,6 +257,7 @@ describe('GetDashboard', () => {
       totalSales: {
         count: mockData.monthlySales[1].count,
         turnover: mockData.monthlySales[1].turnover,
+        turnoverHT: mockData.totalSales.turnoverHT,
         averageBasketValue: mockData.monthlySales[1].averageBasketValue,
         canceledTurnover: mockData.monthlySales[1].canceledTurnover,
         deliveryPrice: mockData.monthlySales[1].deliveryPrice
@@ -258,7 +268,8 @@ describe('GetDashboard', () => {
       ordersByLaboratory: mockData.ordersByLaboratory,
       productQuantitiesByCategory: mockData.productQuantitiesByCategory,
       productStockStats: mockData.productStockStats,
-      userStatistics: mockData.userStatistics
+      userStatistics: mockData.userStatistics,
+      revenueByTaxRate: mockData.revenueByTaxRate
     })
   })
 
@@ -277,7 +288,8 @@ describe('GetDashboard', () => {
       ordersByLaboratory: mockData.ordersByLaboratory,
       productQuantitiesByCategory: mockData.productQuantitiesByCategory,
       productStockStats: mockData.productStockStats,
-      userStatistics: mockData.userStatistics
+      userStatistics: mockData.userStatistics,
+      revenueByTaxRate: mockData.revenueByTaxRate
     })
   })
 
@@ -296,7 +308,8 @@ describe('GetDashboard', () => {
       ordersByLaboratory: mockData.ordersByLaboratory,
       productQuantitiesByCategory: mockData.productQuantitiesByCategory,
       productStockStats: mockData.productStockStats,
-      userStatistics: mockData.userStatistics
+      userStatistics: mockData.userStatistics,
+      revenueByTaxRate: mockData.revenueByTaxRate
     })
   })
 

--- a/src/core/usecases/dashboard/get-dashboard/inMemoryDashboardGateway.ts
+++ b/src/core/usecases/dashboard/get-dashboard/inMemoryDashboardGateway.ts
@@ -15,6 +15,7 @@ export class InMemoryDashboardGateway implements DashboardGateway {
       totalSales: {
         count: 0,
         turnover: 0,
+        turnoverHT: 0,
         averageBasketValue: 0,
         canceledTurnover: 0,
         deliveryPrice: 0
@@ -22,6 +23,7 @@ export class InMemoryDashboardGateway implements DashboardGateway {
       previousYearTotalSales: {
         count: 0,
         turnover: 0,
+        turnoverHT: 0,
         averageBasketValue: 0,
         canceledTurnover: 0,
         deliveryPrice: 0
@@ -43,7 +45,8 @@ export class InMemoryDashboardGateway implements DashboardGateway {
           subscribers: 0,
           nonSubscribers: 0
         }
-      }
+      },
+      revenueByTaxRate: []
     }
   }
 
@@ -98,6 +101,7 @@ export class InMemoryDashboardGateway implements DashboardGateway {
       totalSales: {
         count: totalCount,
         turnover: totalTurnover,
+        turnoverHT: this.mockData.totalSales.turnoverHT,
         averageBasketValue,
         canceledTurnover: 0,
         deliveryPrice: 0
@@ -108,7 +112,8 @@ export class InMemoryDashboardGateway implements DashboardGateway {
       ordersByLaboratory: this.mockData.ordersByLaboratory,
       productQuantitiesByCategory: this.mockData.productQuantitiesByCategory,
       productStockStats: this.mockData.productStockStats,
-      userStatistics: this.mockData.userStatistics
+      userStatistics: this.mockData.userStatistics,
+      revenueByTaxRate: this.mockData.revenueByTaxRate
     }
   }
 


### PR DESCRIPTION
Adds a Chiffre d'affaires HT KPI card next to the existing CA TTC card and a pie chart breaking down CA TTC by tax rate, with separate slices for each product VAT rate and for delivery at 20%. Restructures the KPI grid to prevent 6-digit amounts from overflowing: values stay on one line with tabular-nums, previous-year comparison is shown as a muted caption below the hero figure rather than side-by-side.