### PR TITLE
feat: display order lifecycle timeline on admin order detail (#131)

### DIFF
--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -92,7 +92,26 @@
     "supportTickets": "Tickets de support"
   },
   "orders": {
-    "supportTickets": "Tickets de support"
+    "supportTickets": "Tickets de support",
+    "timeline": {
+      "title": "Historique",
+      "empty": "Aucun événement à afficher",
+      "events": {
+        "placed": "Commande passée",
+        "paid": "Paiement confirmé",
+        "paymentRejected": "Paiement rejeté",
+        "preparationStarted": "Préparation démarrée",
+        "preparationSaved": "Préparation sauvegardée",
+        "preparationValidated": "Préparation validée",
+        "preparationCanceled": "Préparation annulée",
+        "shipped": "Expédiée",
+        "delivered": "Livrée"
+      },
+      "actor": {
+        "system": "Système",
+        "unknown": "Inconnu"
+      }
+    }
   },
   "dashboard": {
     "title": "Tableau de bord",

--- a/src/adapters/primary/nuxt/components/molecules/FtOrderTimeline.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtOrderTimeline.vue
@@ -1,0 +1,85 @@
+<template lang="pug">
+section.flex.flex-col.gap-4(:aria-label="$t('orders.timeline.title')")
+  h2.text-lg.font-semibold {{ $t('orders.timeline.title') }}
+  ol.flex.flex-col(v-if="entries.length > 0")
+    li.flex.items-start.gap-3(
+      v-for="(entry, index) in entries"
+      :key="`${entry.type}-${entry.timestamp}-${index}`"
+    )
+      .flex.flex-col.items-center.shrink-0
+        .flex.h-6.w-6.items-center.justify-center(:class="iconColor(entry.type)")
+          UIcon.h-5.w-5(:name="iconName(entry.type)" aria-hidden="true")
+        .w-px.flex-1.bg-gray-200(v-if="index < entries.length - 1")
+      .flex.flex-1.items-baseline.justify-between.gap-3.min-w-0.pb-4
+        .flex.items-baseline.gap-2.min-w-0
+          span.font-medium.truncate {{ $t(entry.labelKey) }}
+          span.text-sm.text-gray-500.shrink-0 {{ entry.timestamp }}
+        span.text-sm.text-gray-500.shrink-0 {{ actorLabel(entry.actor) }}
+  p.text-sm.text-gray-500(v-else) {{ $t('orders.timeline.empty') }}
+</template>
+
+<script lang="ts" setup>
+import type {
+  TimelineActorVM,
+  TimelineEntryVM
+} from '@adapters/primary/view-models/orders/get-order-timeline/getOrderTimelineVM'
+import { TimelineEntryType } from '@core/entities/orderTimeline'
+
+defineProps<{
+  entries: Array<TimelineEntryVM>
+}>()
+
+const { t } = useI18n()
+
+const actorLabel = (actor: TimelineActorVM): string => {
+  if (actor.kind === 'staff') return actor.name
+  if (actor.kind === 'system') return t('orders.timeline.actor.system')
+  return t('orders.timeline.actor.unknown')
+}
+
+const iconName = (type: TimelineEntryType): string => {
+  switch (type) {
+    case TimelineEntryType.Placed:
+      return 'i-heroicons-shopping-bag'
+    case TimelineEntryType.Paid:
+      return 'i-heroicons-credit-card'
+    case TimelineEntryType.PaymentRejected:
+      return 'i-heroicons-credit-card'
+    case TimelineEntryType.PreparationStarted:
+      return 'i-heroicons-play'
+    case TimelineEntryType.PreparationSaved:
+      return 'i-heroicons-bookmark-square'
+    case TimelineEntryType.PreparationValidated:
+      return 'i-heroicons-check-badge'
+    case TimelineEntryType.PreparationCanceled:
+      return 'i-heroicons-x-circle'
+    case TimelineEntryType.Shipped:
+      return 'i-heroicons-truck'
+    case TimelineEntryType.Delivered:
+      return 'i-heroicons-home'
+  }
+}
+
+const iconColor = (type: TimelineEntryType): string => {
+  switch (type) {
+    case TimelineEntryType.Placed:
+      return 'text-gray-500'
+    case TimelineEntryType.Paid:
+      return 'text-green-500'
+    case TimelineEntryType.PaymentRejected:
+      return 'text-red-500'
+    case TimelineEntryType.PreparationStarted:
+      return 'text-blue-500'
+    case TimelineEntryType.PreparationSaved:
+      return 'text-amber-500'
+    case TimelineEntryType.PreparationValidated:
+      return 'text-green-500'
+    case TimelineEntryType.PreparationCanceled:
+      return 'text-red-500'
+    case TimelineEntryType.Shipped:
+      return 'text-orange-500'
+    case TimelineEntryType.Delivered:
+      return 'text-green-500'
+  }
+}
+</script>

--- a/src/adapters/primary/nuxt/pages/orders/[uuid].vue
+++ b/src/adapters/primary/nuxt/pages/orders/[uuid].vue
@@ -22,7 +22,7 @@
       div.flex.items-center
         p Statut du paiement :
         ft-payment-status-badge.ml-2(:status="orderVM.paymentStatus")
-  ft-preparation-table(:vm="preparationVM")
+  ft-preparation-table.mt-8(:vm="preparationVM")
   div.flex.flex-row-reverse.gap-4
     div(v-if="orderVM.invoiceNumber")
       ft-button.button-default.mt-4.mr-0.py-4.px-4.text-xl(
@@ -68,6 +68,7 @@
           variant="outline"
           @click="downloadLabel(item)"
         ) Télécharger
+  ft-order-timeline.mt-8(:entries="timelineVM.entries")
   h2.text-subtitle.mt-8 {{ $t('orders.supportTickets') }}
   order-tickets-list(:order-uuid="orderUuid")
 
@@ -75,6 +76,7 @@
 
 <script lang="ts" setup>
 import { getOrderVM } from '@adapters/primary/view-models/orders/get-order/getOrderVM'
+import { getOrderTimelineVM } from '@adapters/primary/view-models/orders/get-order-timeline/getOrderTimelineVM'
 import { getPreparationVM } from '@adapters/primary/view-models/preparations/get-preparation/getPreparationVM'
 import { downloadDeliveryLabel } from '@core/usecases/deliveries/delivery-label-download/downloadDeliveryLabel'
 import { printDeliveryLabel } from '@core/usecases/deliveries/delivery-label-printing/printDeliveryLabel'
@@ -107,6 +109,10 @@ const preparationVM = computed(() => {
 
 const orderVM = computed(() => {
   return getOrderVM()
+})
+
+const timelineVM = computed(() => {
+  return getOrderTimelineVM()
 })
 
 const printLabel = (delivery: { uuid: string }) => {

--- a/src/adapters/primary/view-models/orders/get-order-timeline/getOrderTimelineVM.spec.ts
+++ b/src/adapters/primary/view-models/orders/get-order-timeline/getOrderTimelineVM.spec.ts
@@ -1,0 +1,121 @@
+import {
+  GetOrderTimelineVM,
+  getOrderTimelineVM,
+  TimelineEntryVM
+} from '@adapters/primary/view-models/orders/get-order-timeline/getOrderTimelineVM'
+import { Order } from '@core/entities/order'
+import { TimelineEntryType } from '@core/entities/orderTimeline'
+import { useOrderStore } from '@store/orderStore'
+import { orderToPrepare1 } from '@utils/testData/orders'
+import { createPinia, setActivePinia } from 'pinia'
+
+describe('Get order timeline VM', () => {
+  let orderStore: any
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    orderStore = useOrderStore()
+  })
+
+  describe('There is no current order', () => {
+    it('should return an empty list of entries', () => {
+      const vm = getOrderTimelineVM()
+      const expected: GetOrderTimelineVM = { entries: [] }
+      expect(vm).toStrictEqual(expected)
+    })
+  })
+
+  describe('The current order has no timeline yet', () => {
+    it('should return an empty list of entries', () => {
+      const order: Order = JSON.parse(JSON.stringify(orderToPrepare1))
+      delete order.timeline
+      orderStore.setCurrent(order)
+      const vm = getOrderTimelineVM()
+      expect(vm.entries).toStrictEqual([])
+    })
+  })
+
+  describe('The current order has a timeline with a staff actor', () => {
+    let order: Order
+    const placedAt = 1_700_000_000_000
+
+    beforeEach(() => {
+      order = JSON.parse(JSON.stringify(orderToPrepare1))
+      order.timeline = [
+        {
+          type: TimelineEntryType.PreparationStarted,
+          createdAt: placedAt,
+          actor: {
+            kind: 'staff',
+            email: 'marie@phardev.fr',
+            firstname: 'Marie',
+            lastname: 'Dupont'
+          }
+        }
+      ]
+      orderStore.setCurrent(order)
+    })
+
+    it('should expose the entry with i18n key, formatted timestamp and actor name', () => {
+      const expected: TimelineEntryVM = {
+        type: TimelineEntryType.PreparationStarted,
+        labelKey: 'orders.timeline.events.preparationStarted',
+        timestamp: '14/11/2023 22:13',
+        actor: { kind: 'staff', name: 'Marie Dupont' }
+      }
+      expect(getOrderTimelineVM().entries).toStrictEqual([expected])
+    })
+  })
+
+  describe('The current order has a staff actor with no firstname/lastname', () => {
+    it('should fall back to the actor email', () => {
+      const order: Order = JSON.parse(JSON.stringify(orderToPrepare1))
+      order.timeline = [
+        {
+          type: TimelineEntryType.PreparationSaved,
+          createdAt: 1_700_000_000_000,
+          actor: { kind: 'staff', email: 'no-name@phardev.fr' }
+        }
+      ]
+      orderStore.setCurrent(order)
+      expect(getOrderTimelineVM().entries[0].actor).toStrictEqual({
+        kind: 'staff',
+        name: 'no-name@phardev.fr'
+      })
+    })
+  })
+
+  describe('The current order has a system actor', () => {
+    it('should expose the actor as system', () => {
+      const order: Order = JSON.parse(JSON.stringify(orderToPrepare1))
+      order.timeline = [
+        {
+          type: TimelineEntryType.Paid,
+          createdAt: 1_700_000_000_000,
+          actor: { kind: 'system' }
+        }
+      ]
+      orderStore.setCurrent(order)
+      expect(getOrderTimelineVM().entries[0].actor).toStrictEqual({
+        kind: 'system'
+      })
+    })
+  })
+
+  describe('The current order has an unknown actor (legacy data)', () => {
+    it('should expose the actor as unknown', () => {
+      const order: Order = JSON.parse(JSON.stringify(orderToPrepare1))
+      order.timeline = [
+        {
+          type: TimelineEntryType.Placed,
+          createdAt: 1_700_000_000_000,
+          actor: { kind: 'unknown' }
+        }
+      ]
+      orderStore.setCurrent(order)
+      expect(getOrderTimelineVM().entries[0].actor).toStrictEqual({
+        kind: 'unknown'
+      })
+    })
+  })
+})

--- a/src/adapters/primary/view-models/orders/get-order-timeline/getOrderTimelineVM.ts
+++ b/src/adapters/primary/view-models/orders/get-order-timeline/getOrderTimelineVM.ts
@@ -1,0 +1,71 @@
+import {
+  TimelineActor,
+  TimelineEntry,
+  TimelineEntryType
+} from '@core/entities/orderTimeline'
+import { useOrderStore } from '@store/orderStore'
+import { timestampToLocaleString } from '@utils/formatters'
+
+export type TimelineActorVM =
+  | { kind: 'staff'; name: string }
+  | { kind: 'system' }
+  | { kind: 'unknown' }
+
+export interface TimelineEntryVM {
+  type: TimelineEntryType
+  labelKey: string
+  timestamp: string
+  actor: TimelineActorVM
+}
+
+export interface GetOrderTimelineVM {
+  entries: Array<TimelineEntryVM>
+}
+
+const labelKeys: Record<TimelineEntryType, string> = {
+  [TimelineEntryType.Placed]: 'orders.timeline.events.placed',
+  [TimelineEntryType.Paid]: 'orders.timeline.events.paid',
+  [TimelineEntryType.PaymentRejected]: 'orders.timeline.events.paymentRejected',
+  [TimelineEntryType.PreparationStarted]:
+    'orders.timeline.events.preparationStarted',
+  [TimelineEntryType.PreparationSaved]:
+    'orders.timeline.events.preparationSaved',
+  [TimelineEntryType.PreparationValidated]:
+    'orders.timeline.events.preparationValidated',
+  [TimelineEntryType.PreparationCanceled]:
+    'orders.timeline.events.preparationCanceled',
+  [TimelineEntryType.Shipped]: 'orders.timeline.events.shipped',
+  [TimelineEntryType.Delivered]: 'orders.timeline.events.delivered'
+}
+
+export const getOrderTimelineVM = (): GetOrderTimelineVM => {
+  const orderStore = useOrderStore()
+  const order = orderStore.current
+  if (!order || !order.timeline) {
+    return { entries: [] }
+  }
+  return {
+    entries: order.timeline.map(toEntryVM)
+  }
+}
+
+const toEntryVM = (entry: TimelineEntry): TimelineEntryVM => ({
+  type: entry.type,
+  labelKey: labelKeys[entry.type],
+  timestamp: timestampToLocaleString(entry.createdAt, 'fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }),
+  actor: toActorVM(entry.actor)
+})
+
+const toActorVM = (actor: TimelineActor): TimelineActorVM => {
+  if (actor.kind === 'staff') {
+    const fullName = `${actor.firstname ?? ''} ${actor.lastname ?? ''}`.trim()
+    return { kind: 'staff', name: fullName || actor.email }
+  }
+  return actor
+}

--- a/src/core/entities/order.ts
+++ b/src/core/entities/order.ts
@@ -1,4 +1,5 @@
 import { Delivery, DeliveryStatus } from '@core/entities/delivery'
+import { TimelineEntry } from '@core/entities/orderTimeline'
 import { Promotion } from '@core/entities/promotion'
 import { Timestamp, UUID } from '@core/types/types'
 import { addTaxToPrice } from '@utils/price'
@@ -101,6 +102,7 @@ export interface BaseOrder {
   invoiceNumber?: string
   customerMessage?: string
   promotionCode?: PromotionCode
+  timeline?: Array<TimelineEntry>
 }
 
 export interface CustomerOrder extends BaseOrder {

--- a/src/core/entities/orderTimeline.ts
+++ b/src/core/entities/orderTimeline.ts
@@ -1,0 +1,24 @@
+import type { Timestamp } from '@core/types/types'
+
+export enum TimelineEntryType {
+  Placed = 'PLACED',
+  Paid = 'PAID',
+  PaymentRejected = 'PAYMENT_REJECTED',
+  PreparationStarted = 'PREPARATION_STARTED',
+  PreparationSaved = 'PREPARATION_SAVED',
+  PreparationValidated = 'PREPARATION_VALIDATED',
+  PreparationCanceled = 'PREPARATION_CANCELED',
+  Shipped = 'SHIPPED',
+  Delivered = 'DELIVERED'
+}
+
+export type TimelineActor =
+  | { kind: 'staff'; email: string; firstname?: string; lastname?: string }
+  | { kind: 'system' }
+  | { kind: 'unknown' }
+
+export interface TimelineEntry {
+  type: TimelineEntryType
+  createdAt: Timestamp
+  actor: TimelineActor
+}


### PR DESCRIPTION
## Summary

- Adds a "Historique" section on the order detail page showing the full lifecycle (placed, paid, preparation started/saved/validated/canceled, shipped, delivered, payment rejected) with timestamps and actor name.
- New `FtOrderTimeline` molecule (atomic design) with vertical connector line, badge-aligned colors and Heroicons matching each transition.
- View model resolves the actor display: `firstname lastname` if available, falling back to `email` when name fields are blank, then `Inconnu` when the staff row is missing entirely.
- The page reads `order.timeline` directly from the backend response (single API call); no separate timeline endpoint.

## Test plan

- [ ] Frontend tests: `TZ=UTC pnpm test run` passes (2414 tests)
- [ ] Lint: `pnpm lint` clean
- [ ] Order detail page renders the timeline above the support tickets list with correct ordering, icons and colors
- [ ] Staff actor without firstname/lastname falls back to email
- [ ] Missing staff row shows "Inconnu"
- [ ] System events show "Système"

🤖 Generated with [Claude Code](https://claude.com/claude-code)