### PR TITLE
feat: add retry button to generate shipping label on order detail (#127)

### DIFF
--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -93,6 +93,10 @@
   },
   "orders": {
     "supportTickets": "Tickets de support",
+    "deliveries": {
+      "generateLabel": "Générer l'étiquette",
+      "generateLabelError": "Échec de la génération de l'étiquette. Veuillez réessayer."
+    },
     "timeline": {
       "title": "Historique",
       "empty": "Aucun événement à afficher",

--- a/src/adapters/primary/nuxt/pages/orders/[uuid].vue
+++ b/src/adapters/primary/nuxt/pages/orders/[uuid].vue
@@ -46,28 +46,35 @@
   )
     template(#title) Livraison
     template(#actions="{ item }")
-      div.flex.items-center.gap-4
-        nuxt-link(
-          v-if="item.followUrl"
-          :to="item.followUrl"
-          target="_blank"
-        )
-          ft-button.button-default.py-4.px-4(variant="outline" @click.stop) Suivre le colis
-        ft-button.button-default.py-4.px-4(
-          v-if="item.canMarkAsDelivered"
-          variant="outline"
-          @click="markAsDelivered(item)"
-        ) Marquer comme livré
-        ft-button.button-default.py-4.px-4(
-          v-if="item.followUrl"
-          variant="outline"
-          @click="printLabel(item)"
-        ) Etiquette
-        ft-button.button-default.py-4.px-4(
-          v-if="item.followUrl"
-          variant="outline"
-          @click="downloadLabel(item)"
-        ) Télécharger
+      div.flex.flex-col.items-end.gap-1
+        div.flex.items-center.gap-4
+          ft-button.button-default.py-4.px-4(
+            v-if="item.canGenerateLabel"
+            variant="outline"
+            @click="generateLabel"
+          ) {{ $t('orders.deliveries.generateLabel') }}
+          nuxt-link(
+            v-if="item.followUrl"
+            :to="item.followUrl"
+            target="_blank"
+          )
+            ft-button.button-default.py-4.px-4(variant="outline" @click.stop) Suivre le colis
+          ft-button.button-default.py-4.px-4(
+            v-if="item.canMarkAsDelivered"
+            variant="outline"
+            @click="markAsDelivered(item)"
+          ) Marquer comme livré
+          ft-button.button-default.py-4.px-4(
+            v-if="item.followUrl"
+            variant="outline"
+            @click="printLabel(item)"
+          ) Etiquette
+          ft-button.button-default.py-4.px-4(
+            v-if="item.followUrl"
+            variant="outline"
+            @click="downloadLabel(item)"
+          ) Télécharger
+        div.text-red-600.text-sm(v-if="generateLabelError") {{ generateLabelError }}
   ft-order-timeline.mt-8(:entries="timelineVM.entries")
   h2.text-subtitle.mt-8 {{ $t('orders.supportTickets') }}
   order-tickets-list(:order-uuid="orderUuid")
@@ -80,6 +87,7 @@ import { getOrderTimelineVM } from '@adapters/primary/view-models/orders/get-ord
 import { getPreparationVM } from '@adapters/primary/view-models/preparations/get-preparation/getPreparationVM'
 import { downloadDeliveryLabel } from '@core/usecases/deliveries/delivery-label-download/downloadDeliveryLabel'
 import { printDeliveryLabel } from '@core/usecases/deliveries/delivery-label-printing/printDeliveryLabel'
+import { generatePickup } from '@core/usecases/deliveries/delivery-pickup-generation/generatePickup'
 import { markDeliveryAsDelivered } from '@core/usecases/deliveries/mark-delivery-as-delivered/markDeliveryAsDelivered'
 import { getOrder } from '@core/usecases/order/get-order/getOrder'
 import { getPreparation } from '@core/usecases/order/get-preparation/getPreparation'
@@ -96,6 +104,8 @@ const route = useRoute()
 const orderUuid = String(route.params.uuid)
 const router = useRouter()
 const deliveryStore = useDeliveryStore()
+const { t } = useI18n()
+const generateLabelError = ref<string | null>(null)
 
 onMounted(() => {
   getPreparation(orderUuid, useOrderGateway())
@@ -117,6 +127,16 @@ const timelineVM = computed(() => {
 
 const printLabel = (delivery: { uuid: string }) => {
   printDeliveryLabel(delivery.uuid, useDeliveryGateway())
+}
+
+const generateLabel = async () => {
+  generateLabelError.value = null
+  try {
+    await generatePickup(orderUuid, useDeliveryGateway())
+    await getOrder(orderUuid, useOrderGateway(), useCustomerGateway())
+  } catch {
+    generateLabelError.value = t('orders.deliveries.generateLabelError')
+  }
 }
 
 const downloadLabel = async (delivery: { uuid: string }) => {

--- a/src/adapters/primary/view-models/orders/get-order/getOrderVM.spec.ts
+++ b/src/adapters/primary/view-models/orders/get-order/getOrderVM.spec.ts
@@ -444,7 +444,11 @@ describe('Get order VM', () => {
       trackingNumber: delivery.trackingNumber ?? '',
       weight: delivery.weight / 1000,
       status: delivery.status,
-      canMarkAsDelivered: delivery.method.type === DeliveryType.ClickAndCollect
+      canMarkAsDelivered: delivery.method.type === DeliveryType.ClickAndCollect,
+      canGenerateLabel:
+        delivery.method.type === DeliveryType.Delivery &&
+        delivery.status === DeliveryStatus.Prepared &&
+        !delivery.trackingNumber
     }
     if (delivery.trackingNumber) {
       res.followUrl = `https://laposte.fr/outils/suivre-vos-envois?code=${delivery.trackingNumber}`

--- a/src/adapters/primary/view-models/orders/get-order/getOrderVM.ts
+++ b/src/adapters/primary/view-models/orders/get-order/getOrderVM.ts
@@ -30,6 +30,7 @@ export interface OrderDeliveriesItemVM {
   status: DeliveryStatus
   followUrl?: string
   canMarkAsDelivered: boolean
+  canGenerateLabel: boolean
 }
 
 export interface GetOrderVM {
@@ -107,7 +108,11 @@ export const getOrderVM = (): GetOrderVM => {
         weight: delivery.weight / 1000,
         status: delivery.status,
         canMarkAsDelivered:
-          delivery.method.type === DeliveryType.ClickAndCollect
+          delivery.method.type === DeliveryType.ClickAndCollect,
+        canGenerateLabel:
+          delivery.method.type === DeliveryType.Delivery &&
+          delivery.status === DeliveryStatus.Prepared &&
+          !delivery.trackingNumber
       }
       if (delivery.trackingNumber) {
         res.followUrl = `https://laposte.fr/outils/suivre-vos-envois?code=${delivery.trackingNumber}`

--- a/src/adapters/secondary/delivery-gateways/inMemoryDeliveryGateway.ts
+++ b/src/adapters/secondary/delivery-gateways/inMemoryDeliveryGateway.ts
@@ -6,6 +6,8 @@ export class InMemoryDeliveryGateway implements DeliveryGateway {
   private deliveries: Array<Delivery> = []
   private printed: Array<UUID> = []
   private downloaded: Array<UUID> = []
+  private generatedPickups: Array<UUID> = []
+  private generatePickupError: Error | null = null
 
   list(): Promise<Array<Delivery>> {
     return Promise.resolve(JSON.parse(JSON.stringify(this.deliveries)))
@@ -41,12 +43,28 @@ export class InMemoryDeliveryGateway implements DeliveryGateway {
     return Promise.resolve(JSON.parse(JSON.stringify(this.deliveries[index])))
   }
 
+  generatePickup(orderUuid: UUID): Promise<void> {
+    if (this.generatePickupError) {
+      return Promise.reject(this.generatePickupError)
+    }
+    this.generatedPickups.push(orderUuid)
+    return Promise.resolve()
+  }
+
   listPrinted(): Array<UUID> {
     return this.printed
   }
 
   listDownloaded(): Array<UUID> {
     return this.downloaded
+  }
+
+  listGeneratedPickups(): Array<UUID> {
+    return this.generatedPickups
+  }
+
+  feedGeneratePickupError(error: Error) {
+    this.generatePickupError = error
   }
 
   feedWith(...deliveries: Array<Delivery>) {

--- a/src/adapters/secondary/delivery-gateways/realDeliveryGateway.ts
+++ b/src/adapters/secondary/delivery-gateways/realDeliveryGateway.ts
@@ -59,6 +59,10 @@ export class RealDeliveryGateway
     return new Blob([res.data], { type: 'application/pdf' })
   }
 
+  async generatePickup(orderUuid: UUID): Promise<void> {
+    await axiosWithBearer.post(`${this.baseUrl}/pickup`, { orderUuid })
+  }
+
   private convertToDelivery(delivery: any) {
     return {
       ...delivery,

--- a/src/core/gateways/deliveryGateway.ts
+++ b/src/core/gateways/deliveryGateway.ts
@@ -7,4 +7,5 @@ export interface DeliveryGateway {
   printLabel(uuid: UUID): Promise<void>
   downloadLabel(uuid: UUID): Promise<Blob>
   markAsDelivered(uuid: UUID): Promise<Delivery>
+  generatePickup(orderUuid: UUID): Promise<void>
 }

--- a/src/core/usecases/deliveries/delivery-pickup-generation/generatePickup.spec.ts
+++ b/src/core/usecases/deliveries/delivery-pickup-generation/generatePickup.spec.ts
@@ -1,0 +1,18 @@
+import { InMemoryDeliveryGateway } from '@adapters/secondary/delivery-gateways/inMemoryDeliveryGateway'
+import { generatePickup } from '@core/usecases/deliveries/delivery-pickup-generation/generatePickup'
+import { orderPrepared1 } from '@utils/testData/orders'
+
+describe('Generate pickup', () => {
+  let deliveryGateway: InMemoryDeliveryGateway
+
+  beforeEach(() => {
+    deliveryGateway = new InMemoryDeliveryGateway()
+  })
+
+  it('should generate the pickup for the given order', async () => {
+    await generatePickup(orderPrepared1.uuid, deliveryGateway)
+    expect(deliveryGateway.listGeneratedPickups()).toStrictEqual([
+      orderPrepared1.uuid
+    ])
+  })
+})

--- a/src/core/usecases/deliveries/delivery-pickup-generation/generatePickup.ts
+++ b/src/core/usecases/deliveries/delivery-pickup-generation/generatePickup.ts
@@ -1,0 +1,9 @@
+import { DeliveryGateway } from '@core/gateways/deliveryGateway'
+import { UUID } from '@core/types/types'
+
+export const generatePickup = async (
+  orderUuid: UUID,
+  deliveryGateway: DeliveryGateway
+) => {
+  await deliveryGateway.generatePickup(orderUuid)
+}


### PR DESCRIPTION
## Summary
- Adds a 'Générer l'étiquette' button on the order detail page, visible when the delivery is a postal delivery, the order is prepared, and no tracking number exists.
- On click, calls `POST /pickup` (existing endpoint) via a new `generatePickup` usecase, then re-fetches the order; the existing `Etiquette` / `Télécharger` / `Suivre le colis` buttons appear once the tracking number is set.
- On failure, an inline error message is shown next to the deliveries-table actions.
- Companion backend resilience fix: phardev/ecommerce-backend#44.

## Test plan
- [x] `pnpm vue-tsc --noEmit` clean
- [x] `pnpm lint` (biome) clean
- [x] `TZ=UTC pnpm test run` — affected suites pass (`generatePickup.spec.ts`, `getOrderVM.spec.ts`)
- [ ] Smoke: open a Delivery-type prepared order with no tracking number → button visible → click → success path replaces with existing buttons; failure path shows inline error.
- [ ] Sanity: ClickAndCollect order shows only 'Marquer comme livré'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)