### PR TITLE
chore: hide Relances menu and permission from admin UI (#136)

### DIFF
--- a/src/adapters/primary/view-models/navigation-menu/get-navigation-menu/getNavigationMenuVM.spec.ts
+++ b/src/adapters/primary/view-models/navigation-menu/get-navigation-menu/getNavigationMenuVM.spec.ts
@@ -43,7 +43,7 @@ describe('Get navigation menu VM', () => {
     })
   })
 
-  describe('Assistant user (dashboard, reminders, customers, newsletter, support, preparations and orders permissions)', () => {
+  describe('Assistant user (dashboard, customers, newsletter, support, preparations and orders permissions)', () => {
     it('should show only pages assistant has permission for', () => {
       givenUserProfile(assistantUserProfile)
       whenGetNavigationMenuVM()
@@ -58,11 +58,6 @@ describe('Get navigation menu VM', () => {
                 name: 'Tableau de bord',
                 icon: 'akar-icons:statistic-up',
                 href: '/dashboard'
-              },
-              {
-                name: 'Relances',
-                icon: 'mdi:bell-outline',
-                href: '/reminders'
               }
             ]
           },
@@ -126,11 +121,6 @@ describe('Get navigation menu VM', () => {
                 name: 'Tableau de bord',
                 icon: 'akar-icons:statistic-up',
                 href: '/dashboard'
-              },
-              {
-                name: 'Relances',
-                icon: 'mdi:bell-outline',
-                href: '/reminders'
               }
             ]
           },

--- a/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
+++ b/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
@@ -103,9 +103,7 @@ const getOrderItemVM = (order: Order): GetOrdersItemVM => {
   }
 }
 
-const isAnyFilterActive = (
-  filter: SearchOrdersDTO | undefined
-): boolean => {
+const isAnyFilterActive = (filter: SearchOrdersDTO | undefined): boolean => {
   if (!filter) return false
   return Boolean(
     filter.query ||

--- a/src/adapters/primary/view-models/permissions/get-permission-matrix/getPermissionMatrixVM.spec.ts
+++ b/src/adapters/primary/view-models/permissions/get-permission-matrix/getPermissionMatrixVM.spec.ts
@@ -37,7 +37,6 @@ describe('Get permission matrix view model', () => {
 
       expect(result.permissions['role-admin']).toStrictEqual({
         dashboard: true,
-        reminders: true,
         products: true,
         laboratories: true,
         categories: true,
@@ -62,7 +61,6 @@ describe('Get permission matrix view model', () => {
 
       expect(result.permissions['role-pharmacist']).toStrictEqual({
         dashboard: true,
-        reminders: true,
         products: true,
         laboratories: true,
         categories: true,
@@ -87,7 +85,6 @@ describe('Get permission matrix view model', () => {
 
       expect(result.permissions['role-assistant']).toStrictEqual({
         dashboard: true,
-        reminders: true,
         products: false,
         laboratories: false,
         categories: false,

--- a/src/adapters/primary/view-models/permissions/get-permission-matrix/getPermissionMatrixVM.ts
+++ b/src/adapters/primary/view-models/permissions/get-permission-matrix/getPermissionMatrixVM.ts
@@ -1,6 +1,11 @@
+import { PermissionResource } from '@core/entities/permissionResource'
 import { Role } from '@core/entities/role'
 import { useRoleStore } from '@store/roleStore'
 import { useSystemResourceStore } from '@store/systemResourceStore'
+
+const HIDDEN_PERMISSION_RESOURCES: Array<string> = [
+  PermissionResource.REMINDERS
+]
 
 export interface PermissionMatrixVM {
   systemResources: Array<string>
@@ -13,7 +18,9 @@ export const getPermissionMatrixVM = (): PermissionMatrixVM => {
   const roleStore = useRoleStore()
   const systemResourceStore = useSystemResourceStore()
 
-  const systemResources = systemResourceStore.items
+  const systemResources = systemResourceStore.items.filter(
+    (resource: string) => !HIDDEN_PERMISSION_RESOURCES.includes(resource)
+  )
   const roles = roleStore.items
 
   const permissions: Record<string, Record<string, boolean>> = {}

--- a/src/adapters/primary/view-models/permissions/permission-matrix-edit/permissionMatrixEditVM.ts
+++ b/src/adapters/primary/view-models/permissions/permission-matrix-edit/permissionMatrixEditVM.ts
@@ -1,8 +1,13 @@
 import { Permission } from '@core/entities/permission'
+import { PermissionResource } from '@core/entities/permissionResource'
 import { Role } from '@core/entities/role'
 import { UUID } from '@core/types/types'
 import { useRoleStore } from '@store/roleStore'
 import { useSystemResourceStore } from '@store/systemResourceStore'
+
+const HIDDEN_PERMISSION_RESOURCES: Array<string> = [
+  PermissionResource.REMINDERS
+]
 
 export interface PermissionMatrixRole {
   uuid: UUID
@@ -33,7 +38,7 @@ export class PermissionMatrixEditVM {
   private buildPermissionsFromStore(): Record<string, Record<string, boolean>> {
     const permissions: Record<string, Record<string, boolean>> = {}
     const roles = this.roleStore.items
-    const systemResources = this.systemResourceStore.items
+    const systemResources = this.visibleSystemResources()
 
     roles.forEach((role: Role) => {
       permissions[role.uuid] = {}
@@ -71,7 +76,13 @@ export class PermissionMatrixEditVM {
   }
 
   get systemResources(): Array<string> {
-    return this.systemResourceStore.items
+    return this.visibleSystemResources()
+  }
+
+  private visibleSystemResources(): Array<string> {
+    return this.systemResourceStore.items.filter(
+      (resource: string) => !HIDDEN_PERMISSION_RESOURCES.includes(resource)
+    )
   }
 
   get roles(): Array<PermissionMatrixRole> {

--- a/src/adapters/primary/view-models/roles/role-form/roleFormCreateVM.spec.ts
+++ b/src/adapters/primary/view-models/roles/role-form/roleFormCreateVM.spec.ts
@@ -30,9 +30,11 @@ describe('RoleFormCreateVM', () => {
       expect(permissions.every((p) => !p.selected)).toBe(true)
     })
 
-    it('should have all available permission resources', () => {
+    it('should have all available permission resources except hidden ones', () => {
       const permissions = vm.getAvailablePermissions()
-      const expectedResourceCount = Object.values(PermissionResource).length
+      const expectedResourceCount = Object.values(PermissionResource).filter(
+        (resource) => resource !== PermissionResource.REMINDERS
+      ).length
       expect(permissions).toHaveLength(expectedResourceCount)
     })
   })

--- a/src/adapters/primary/view-models/roles/role-form/roleFormEditVM.spec.ts
+++ b/src/adapters/primary/view-models/roles/role-form/roleFormEditVM.spec.ts
@@ -72,9 +72,11 @@ describe('RoleFormEditVM', () => {
   })
 
   describe('Available permissions', () => {
-    it('should provide all permission resources', () => {
+    it('should provide all permission resources except hidden ones', () => {
       const permissions = vm.getAvailablePermissions()
-      const expectedCount = Object.values(PermissionResource).length
+      const expectedCount = Object.values(PermissionResource).filter(
+        (resource) => resource !== PermissionResource.REMINDERS
+      ).length
 
       expect(permissions).toHaveLength(expectedCount)
     })

--- a/src/adapters/primary/view-models/roles/role-form/roleFormVM.ts
+++ b/src/adapters/primary/view-models/roles/role-form/roleFormVM.ts
@@ -42,9 +42,8 @@ export class RoleFormFieldsReader extends FormFieldsReader {
       (this.get('permissions') as Array<Permission>) || []
     const selectedResources = selectedPermissions.map((p) => p.resource)
 
-    const permissionLabels: Record<PermissionResource, string> = {
+    const permissionLabels: Partial<Record<PermissionResource, string>> = {
       [PermissionResource.DASHBOARD]: 'Tableau de bord',
-      [PermissionResource.REMINDERS]: 'Rappels',
       [PermissionResource.PRODUCTS]: 'Produits',
       [PermissionResource.LABORATORIES]: 'Laboratoires',
       [PermissionResource.CATEGORIES]: 'Catégories',
@@ -64,11 +63,13 @@ export class RoleFormFieldsReader extends FormFieldsReader {
       [PermissionResource.LOYALTY]: 'Fidélité'
     }
 
-    return Object.values(PermissionResource).map((resource) => ({
-      resource,
-      label: permissionLabels[resource],
-      selected: selectedResources.includes(resource)
-    }))
+    return Object.values(PermissionResource)
+      .filter((resource) => permissionLabels[resource] !== undefined)
+      .map((resource) => ({
+        resource,
+        label: permissionLabels[resource] as string,
+        selected: selectedResources.includes(resource)
+      }))
   }
 }
 

--- a/src/utils/testData/navigationMenu.ts
+++ b/src/utils/testData/navigationMenu.ts
@@ -11,11 +11,6 @@ export const fullMenu: NavigationMenu = {
           name: 'Tableau de bord',
           icon: 'akar-icons:statistic-up',
           href: '/dashboard'
-        },
-        {
-          name: 'Relances',
-          icon: 'mdi:bell-outline',
-          href: '/reminders'
         }
       ]
     },

--- a/src/utils/testData/systemResources.ts
+++ b/src/utils/testData/systemResources.ts
@@ -2,7 +2,6 @@ import { PermissionResource } from '@core/entities/permissionResource'
 
 export const systemResources = [
   PermissionResource.DASHBOARD,
-  PermissionResource.REMINDERS,
   PermissionResource.PRODUCTS,
   PermissionResource.LABORATORIES,
   PermissionResource.CATEGORIES,


### PR DESCRIPTION
## Summary
- Removes the "Relances" link from the admin sidebar (`Statistiques` section)
- Hides the `REMINDERS` row from the role-permission matrix on `/staff` and from the role create/edit form, applied at the view-model layer so backend-served REMINDERS resources are also filtered
- Updates affected specs

## Why
"Relances" is a non-operational stats screen. Exposing it in the sidebar and the role-permission matrix lets admins grant access to a broken page. We hide the UI without deleting the underlying implementation so the feature can be reactivated later.

## Scope kept intact (per issue #136)
- `core/usecases/reminders/*`, the reminders gateways, view-models, Pinia store entry, and the `/reminders` page component are unchanged
- `PermissionResource.REMINDERS` enum value is preserved — persisted role records still load without error

## Test plan
- [x] `TZ=UTC pnpm test run` — 207 files / 2426 tests pass
- [x] `pnpm vue-tsc --noEmit`
- [x] `pnpm lint`
- [x] Manual: sidebar shows `Statistiques` with only `Tableau de bord`; role-permission matrix has no `Rappels` row; roles previously holding `reminders` still load

Refs phardev/ecommerce#136

🤖 Generated with [Claude Code](https://claude.com/claude-code)