### PR TITLE
fix(search): stop re-sorting product search results by stock (#141)

### DIFF
--- a/src/adapters/secondary/search-gateways/RealSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/RealSearchGateway.ts
@@ -8,7 +8,6 @@ import {
   OrderLineStatus,
   PaymentStatus
 } from '@core/entities/order'
-import { Product } from '@core/entities/product'
 import {
   SearchGateway,
   SearchProductsResult
@@ -30,9 +29,7 @@ export class RealSearchGateway extends RealGateway implements SearchGateway {
       `${this.baseUrl}/search/products`,
       filters
     )
-    const items = res.data.items.sort(
-      (a: Product, b: Product) => b.availableStock - a.availableStock
-    )
+    const items = res.data.items
     const pagination = res.data.pagination
     const size = filters.size ?? 25
     const from = filters.from ?? 0


### PR DESCRIPTION
## Summary
- Remove the client-side `.sort((a,b) => b.availableStock - a.availableStock)` in `RealSearchGateway.searchProducts`.
- Preserves the backend's relevance ordering (ES `_score desc`) so admin Products page surfaces the most relevant matches on page 1.

## Context
Pairs with phardev/ecommerce-backend#47, which removes the forced `availableStock desc` sort on the admin search endpoint. Without removing this client-side re-sort too, the 25 items returned per page would still be reshuffled by stock in the UI, pushing low-stock-but-highly-relevant matches (like the Hydratis-brand products in #141) to the bottom of each page.

Closes #141

## Test plan
- [x] `TZ=UTC pnpm test run src/core/usecases/product/product-searching` — 44 tests pass
- [x] `pnpm vue-tsc --noEmit` clean
- [x] `pnpm lint` clean
- [ ] Smoke: type "hydratis" in admin Products search → Hydratis products appear in the first results, in backend-provided order
- [ ] Smoke: clear the search → products list renders as before
- [ ] Smoke: search by product name / EAN13 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)