### PR TITLE
fix: derive delivery price rule status from dates instead of plain isActive

### DIFF
--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -83,6 +83,12 @@
       "weightUnit": "kg",
       "selectStartDate": "Sélectionner une date de début",
       "selectEndDate": "Sélectionner une date de fin"
+    },
+    "status": {
+      "disabled": "Désactivée",
+      "upcoming": "À venir",
+      "active": "Active",
+      "expired": "Expirée"
     }
   },
   "customers": {

--- a/src/adapters/primary/nuxt/components/atoms/FtDeliveryPriceRuleStatusBadge.vue
+++ b/src/adapters/primary/nuxt/components/atoms/FtDeliveryPriceRuleStatusBadge.vue
@@ -1,0 +1,21 @@
+<template lang="pug">
+UBadge.uppercase.py-2.px-4(
+  :color="colors[status]"
+  :ui="{ rounded: 'rounded-full' }"
+) {{ $t(`deliveryPriceRules.status.${status}`) }}
+</template>
+
+<script setup lang="ts">
+import type { DeliveryPriceRuleStatus } from '@core/entities/deliveryPriceRule'
+
+defineProps<{
+  status: DeliveryPriceRuleStatus
+}>()
+
+const colors: Record<DeliveryPriceRuleStatus, string> = {
+  disabled: 'gray',
+  upcoming: 'blue',
+  active: 'green',
+  expired: 'orange'
+}
+</script>

--- a/src/adapters/primary/nuxt/pages/delivery-price-rules/index.vue
+++ b/src/adapters/primary/nuxt/pages/delivery-price-rules/index.vue
@@ -47,9 +47,8 @@
         template(#formattedDateRange-data="{ row }")
           span {{ row.formattedDateRange }}
 
-        template(#isActive-data="{ row }")
-          UBadge(:color="row.isActive ? 'green' : 'gray'")
-            | {{ row.isActive ? $t('common.active') : $t('common.inactive') }}
+        template(#status-data="{ row }")
+          FtDeliveryPriceRuleStatusBadge(:status="row.status")
 
         template(#actions-data="{ row }")
           .flex.space-x-2
@@ -97,6 +96,7 @@ import { listDeliveryMethods } from '@core/usecases/delivery-methods/delivery-me
 import { deleteDeliveryPriceRule } from '@core/usecases/delivery-price-rules/delete-delivery-price-rule/deleteDeliveryPriceRule'
 import { listDeliveryPriceRules } from '@core/usecases/delivery-price-rules/list-delivery-price-rules/listDeliveryPriceRules'
 import { useDeliveryPriceRuleStore } from '@store/deliveryPriceRuleStore'
+import { useDateProvider } from '../../../../../../gateways/dateProvider'
 import { useDeliveryMethodGateway } from '../../../../../../gateways/deliveryMethodGateway'
 import { useDeliveryPriceRuleGateway } from '../../../../../../gateways/deliveryPriceRuleGateway'
 
@@ -133,7 +133,7 @@ const columns = computed(() => [
     key: 'formattedDateRange',
     label: t('deliveryPriceRules.fields.dateRange')
   },
-  { key: 'isActive', label: t('deliveryPriceRules.fields.isActive') },
+  { key: 'status', label: t('deliveryPriceRules.fields.isActive') },
   { key: 'actions', label: '' }
 ])
 
@@ -142,7 +142,8 @@ onMounted(async () => {
   await listDeliveryPriceRules(deliveryPriceRuleGateway)
 })
 
-const listVM = computed(() => getDeliveryPriceRuleListVM())
+const dateProvider = useDateProvider()
+const listVM = computed(() => getDeliveryPriceRuleListVM(dateProvider))
 
 const openDeleteModal = (rule: DeliveryPriceRuleListItemVM) => {
   ruleToDelete.value = rule

--- a/src/adapters/primary/view-models/delivery-price-rules/delivery-price-rule-list/deliveryPriceRuleListVM.spec.ts
+++ b/src/adapters/primary/view-models/delivery-price-rules/delivery-price-rule-list/deliveryPriceRuleListVM.spec.ts
@@ -1,3 +1,4 @@
+import { FakeDateProvider } from '@adapters/secondary/date-providers/FakeDateProvider'
 import { useDeliveryMethodStore } from '@store/deliveryMethodStore'
 import { useDeliveryPriceRuleStore } from '@store/deliveryPriceRuleStore'
 import {
@@ -11,6 +12,8 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { getDeliveryPriceRuleListVM } from './deliveryPriceRuleListVM'
 
 describe('deliveryPriceRuleListVM', () => {
+  let dateProvider: FakeDateProvider
+
   beforeEach(() => {
     setActivePinia(createPinia())
     const deliveryMethodStore = useDeliveryMethodStore()
@@ -40,13 +43,15 @@ describe('deliveryPriceRuleListVM', () => {
         priceRanges: []
       }
     ])
+    dateProvider = new FakeDateProvider()
+    dateProvider.feedWith(christmasFreeShipping.startDate!)
   })
 
   it('should return empty array when no rules', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
     expect(result).toStrictEqual([])
   })
@@ -55,16 +60,16 @@ describe('deliveryPriceRuleListVM', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([standardShipping])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
-    expect(result[0].formattedPrice).toStrictEqual('5,90\u00A0€')
+    expect(result[0].formattedPrice).toStrictEqual('5,90 €')
   })
 
   it('should format weight in kg', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([standardShipping])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
     expect(result[0].formattedMaxWeight).toStrictEqual('30 kg')
   })
@@ -73,16 +78,16 @@ describe('deliveryPriceRuleListVM', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([freeShippingOver39])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
-    expect(result[0].formattedMinOrderValue).toStrictEqual('39,00\u00A0€')
+    expect(result[0].formattedMinOrderValue).toStrictEqual('39,00 €')
   })
 
   it('should return dash for date range when no dates', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([standardShipping])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
     expect(result[0].formattedDateRange).toStrictEqual('-')
   })
@@ -91,7 +96,7 @@ describe('deliveryPriceRuleListVM', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([christmasFreeShipping])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
     expect(result[0].formattedDateRange).toStrictEqual(
       '21 déc. 2023 - 31 déc. 2023'
@@ -102,7 +107,7 @@ describe('deliveryPriceRuleListVM', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([standardShipping])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
     expect(result[0].deliveryMethodName).toStrictEqual('Colissimo')
   })
@@ -111,16 +116,55 @@ describe('deliveryPriceRuleListVM', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([standardShipping, freeShippingOver39, christmasFreeShipping])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
     expect(result.map((r) => r.priority)).toStrictEqual([100, 50, 1])
+  })
+
+  it('should expose disabled status when rule is not active', () => {
+    const store = useDeliveryPriceRuleStore()
+    store.list([inactiveRule])
+
+    const result = getDeliveryPriceRuleListVM(dateProvider)
+
+    expect(result[0].status).toStrictEqual('disabled')
+  })
+
+  it('should expose upcoming status when start date is in the future', () => {
+    dateProvider.feedWith(christmasFreeShipping.startDate! - 1)
+    const store = useDeliveryPriceRuleStore()
+    store.list([christmasFreeShipping])
+
+    const result = getDeliveryPriceRuleListVM(dateProvider)
+
+    expect(result[0].status).toStrictEqual('upcoming')
+  })
+
+  it('should expose active status when current date is within range', () => {
+    dateProvider.feedWith(christmasFreeShipping.startDate!)
+    const store = useDeliveryPriceRuleStore()
+    store.list([christmasFreeShipping])
+
+    const result = getDeliveryPriceRuleListVM(dateProvider)
+
+    expect(result[0].status).toStrictEqual('active')
+  })
+
+  it('should expose expired status when end date is reached', () => {
+    dateProvider.feedWith(christmasFreeShipping.endDate!)
+    const store = useDeliveryPriceRuleStore()
+    store.list([christmasFreeShipping])
+
+    const result = getDeliveryPriceRuleListVM(dateProvider)
+
+    expect(result[0].status).toStrictEqual('expired')
   })
 
   it('should map all fields correctly', () => {
     const store = useDeliveryPriceRuleStore()
     store.list([inactiveRule])
 
-    const result = getDeliveryPriceRuleListVM()
+    const result = getDeliveryPriceRuleListVM(dateProvider)
 
     expect(result).toStrictEqual([
       {
@@ -128,12 +172,12 @@ describe('deliveryPriceRuleListVM', () => {
         name: 'Ancienne règle désactivée',
         deliveryMethodUuid: 'delivery-mondial-relay',
         deliveryMethodName: 'Mondial Relay',
-        formattedPrice: '2,99\u00A0€',
-        formattedMinOrderValue: '0,00\u00A0€',
+        formattedPrice: '2,99 €',
+        formattedMinOrderValue: '0,00 €',
         formattedMaxWeight: '10 kg',
         formattedDateRange: '-',
         priority: 5,
-        isActive: false
+        status: 'disabled'
       }
     ])
   })

--- a/src/adapters/primary/view-models/delivery-price-rules/delivery-price-rule-list/deliveryPriceRuleListVM.ts
+++ b/src/adapters/primary/view-models/delivery-price-rules/delivery-price-rule-list/deliveryPriceRuleListVM.ts
@@ -1,4 +1,10 @@
-import type { DeliveryPriceRule } from '@core/entities/deliveryPriceRule'
+import {
+  computeDeliveryPriceRuleStatus,
+  type DeliveryPriceRule,
+  type DeliveryPriceRuleStatus
+} from '@core/entities/deliveryPriceRule'
+import type { DateProvider } from '@core/gateways/dateProvider'
+import type { Timestamp } from '@core/types/types'
 import { useDeliveryMethodStore } from '@store/deliveryMethodStore'
 import { useDeliveryPriceRuleStore } from '@store/deliveryPriceRuleStore'
 import { formatCurrency, timestampToLocaleString } from '@utils/formatters'
@@ -13,7 +19,7 @@ export interface DeliveryPriceRuleListItemVM {
   formattedMaxWeight: string
   formattedDateRange: string
   priority: number
-  isActive: boolean
+  status: DeliveryPriceRuleStatus
 }
 
 const formatWeight = (weightInGrams: number): string => {
@@ -38,7 +44,8 @@ const formatDateRange = (
 
 const mapToVM = (
   rule: DeliveryPriceRule,
-  deliveryMethodName: string
+  deliveryMethodName: string,
+  now: Timestamp
 ): DeliveryPriceRuleListItemVM => {
   return {
     uuid: rule.uuid,
@@ -50,24 +57,26 @@ const mapToVM = (
     formattedMaxWeight: formatWeight(rule.maxWeight),
     formattedDateRange: formatDateRange(rule.startDate, rule.endDate),
     priority: rule.priority,
-    isActive: rule.isActive
+    status: computeDeliveryPriceRuleStatus(rule, now)
   }
 }
 
-export const getDeliveryPriceRuleListVM =
-  (): Array<DeliveryPriceRuleListItemVM> => {
-    const deliveryPriceRuleStore = useDeliveryPriceRuleStore()
-    const deliveryMethodStore = useDeliveryMethodStore()
+export const getDeliveryPriceRuleListVM = (
+  dateProvider: DateProvider
+): Array<DeliveryPriceRuleListItemVM> => {
+  const deliveryPriceRuleStore = useDeliveryPriceRuleStore()
+  const deliveryMethodStore = useDeliveryMethodStore()
+  const now = dateProvider.now()
 
-    const rules = [...deliveryPriceRuleStore.items].sort(
-      (a, b) => b.priority - a.priority
+  const rules = [...deliveryPriceRuleStore.items].sort(
+    (a, b) => b.priority - a.priority
+  )
+
+  return rules.map((rule) => {
+    const deliveryMethod = deliveryMethodStore.items.find(
+      (dm) => dm.uuid === rule.deliveryMethodUuid
     )
-
-    return rules.map((rule) => {
-      const deliveryMethod = deliveryMethodStore.items.find(
-        (dm) => dm.uuid === rule.deliveryMethodUuid
-      )
-      const deliveryMethodName = deliveryMethod?.name || ''
-      return mapToVM(rule, deliveryMethodName)
-    })
-  }
+    const deliveryMethodName = deliveryMethod?.name || ''
+    return mapToVM(rule, deliveryMethodName, now)
+  })
+}

--- a/src/core/entities/deliveryPriceRule.spec.ts
+++ b/src/core/entities/deliveryPriceRule.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeDeliveryPriceRuleStatus,
+  type DeliveryPriceRule
+} from './deliveryPriceRule'
+
+const baseRule: DeliveryPriceRule = {
+  uuid: 'rule-1',
+  deliveryMethodUuid: 'delivery-method-1',
+  name: 'Rule',
+  price: 0,
+  minOrderValue: 0,
+  maxWeight: 30000,
+  priority: 0,
+  startDate: null,
+  endDate: null,
+  isActive: true,
+  createdAt: 1700000000000,
+  createdBy: 'admin@example.com',
+  updatedAt: 1700000000000,
+  updatedBy: 'admin@example.com'
+}
+
+const now = 1_703_500_000_000
+
+describe('computeDeliveryPriceRuleStatus', () => {
+  it('should return disabled when rule is not active', () => {
+    const rule = { ...baseRule, isActive: false }
+
+    expect(computeDeliveryPriceRuleStatus(rule, now)).toStrictEqual('disabled')
+  })
+
+  it('should return disabled when not active even with dates in the future', () => {
+    const rule = {
+      ...baseRule,
+      isActive: false,
+      startDate: now + 1,
+      endDate: now + 2
+    }
+
+    expect(computeDeliveryPriceRuleStatus(rule, now)).toStrictEqual('disabled')
+  })
+
+  it('should return upcoming when active and start date is in the future', () => {
+    const rule = { ...baseRule, startDate: now + 1 }
+
+    expect(computeDeliveryPriceRuleStatus(rule, now)).toStrictEqual('upcoming')
+  })
+
+  it('should return expired when active and end date is reached', () => {
+    const rule = { ...baseRule, endDate: now }
+
+    expect(computeDeliveryPriceRuleStatus(rule, now)).toStrictEqual('expired')
+  })
+
+  it('should return expired when active and end date is in the past', () => {
+    const rule = { ...baseRule, endDate: now - 1 }
+
+    expect(computeDeliveryPriceRuleStatus(rule, now)).toStrictEqual('expired')
+  })
+
+  it('should return active when active and no dates set', () => {
+    expect(computeDeliveryPriceRuleStatus(baseRule, now)).toStrictEqual(
+      'active'
+    )
+  })
+
+  it('should return active when within date range', () => {
+    const rule = { ...baseRule, startDate: now - 1, endDate: now + 1 }
+
+    expect(computeDeliveryPriceRuleStatus(rule, now)).toStrictEqual('active')
+  })
+
+  it('should return active when start date is reached exactly', () => {
+    const rule = { ...baseRule, startDate: now }
+
+    expect(computeDeliveryPriceRuleStatus(rule, now)).toStrictEqual('active')
+  })
+})

--- a/src/core/entities/deliveryPriceRule.ts
+++ b/src/core/entities/deliveryPriceRule.ts
@@ -23,3 +23,19 @@ export type CreateDeliveryPriceRuleDTO = Omit<
 >
 
 export type EditDeliveryPriceRuleDTO = Partial<CreateDeliveryPriceRuleDTO>
+
+export type DeliveryPriceRuleStatus =
+  | 'disabled'
+  | 'upcoming'
+  | 'active'
+  | 'expired'
+
+export const computeDeliveryPriceRuleStatus = (
+  rule: DeliveryPriceRule,
+  now: Timestamp
+): DeliveryPriceRuleStatus => {
+  if (!rule.isActive) return 'disabled'
+  if (rule.startDate && now < rule.startDate) return 'upcoming'
+  if (rule.endDate && now >= rule.endDate) return 'expired'
+  return 'active'
+}


### PR DESCRIPTION
## Summary
- Replace the boolean `isActive` badge on the delivery price rules list with a derived `status` (`disabled | upcoming | active | expired`) computed in the VM from `isActive` + `startDate`/`endDate` + current date
- Stops showing "Actif" for rules whose date window is in the future or past (e.g. "Livraison gratuite Noël" with dates from Dec 2023)
- New atom `FtDeliveryPriceRuleStatusBadge` with colored variants (gray/blue/green/orange)
- `DateProvider` is now injected into `getDeliveryPriceRuleListVM` (same pattern as banners/promotions VMs)

## Implementation notes
- Status helper `computeDeliveryPriceRuleStatus` lives in the entity (`src/core/entities/deliveryPriceRule.ts`), consistent with `banner.ts` helpers — `disabled` overrides any date-derived state
- Backend untouched; this is purely a display concern
- Out of scope (worth follow-ups): filter/sort by status, status-specific row actions, persisting the rule applied to each order

## Test plan
- [x] `TZ=UTC pnpm test run src/core/entities/deliveryPriceRule.spec.ts` (8 tests, status logic)
- [x] `TZ=UTC pnpm test run src/adapters/primary/view-models/delivery-price-rules/delivery-price-rule-list/deliveryPriceRuleListVM.spec.ts` (13 tests, 4 dedicated to status values)
- [x] `pnpm lint` clean
- [ ] Manual smoke test on `/delivery-price-rules`: create 4 rules covering each status and verify badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)