### PR TITLE
feat: add Total TTC filter and rework orders filters UX (#144)

### DIFF
--- a/src/adapters/primary/nuxt/components/molecules/FtDeliveryStatusSelect.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtDeliveryStatusSelect.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-div.flex.items-center.justify-center
-  USelectMenu.w-32(
+div.flex.items-center.gap-2
+  USelectMenu.flex-grow(
     v-model="model"
     :options="options"
   )

--- a/src/adapters/primary/nuxt/components/molecules/FtFilterChips.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtFilterChips.vue
@@ -1,0 +1,40 @@
+<template lang="pug">
+div.flex.flex-wrap.items-center.gap-2(v-if="filters.length")
+  UButton(
+    v-for="(filter, index) in filters"
+    :key="index"
+    color="gray"
+    variant="soft"
+    size="xs"
+    trailing-icon="i-heroicons-x-mark-20-solid"
+    :aria-label="`Retirer le filtre ${filter.label}`"
+    @click="remove(filter)"
+  ) {{ filter.label }}
+  UButton(
+    color="gray"
+    variant="link"
+    size="xs"
+    @click="clearAll"
+  ) Tout effacer
+</template>
+
+<script lang="ts" setup>
+import type { ActiveFilterVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
+
+defineProps<{
+  filters: Array<ActiveFilterVM>
+}>()
+
+const emit = defineEmits<{
+  (e: 'remove', filter: ActiveFilterVM): void
+  (e: 'clearAll'): void
+}>()
+
+const remove = (filter: ActiveFilterVM) => {
+  emit('remove', filter)
+}
+
+const clearAll = () => {
+  emit('clearAll')
+}
+</script>

--- a/src/adapters/primary/nuxt/components/molecules/FtOrderStatusSelect.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtOrderStatusSelect.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-div.flex.items-center.justify-center
-  USelectMenu.w-44(
+div.flex.items-center.gap-2
+  USelectMenu.flex-grow(
     v-model="model"
     :options="options"
   )

--- a/src/adapters/primary/nuxt/components/molecules/FtPaymentStatusSelect.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPaymentStatusSelect.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-div.flex.items-center.justify-center
-  USelectMenu.w-44(
+div.flex.items-center.gap-2
+  USelectMenu.flex-grow(
     v-model="model"
     :options="options"
   )

--- a/src/adapters/primary/nuxt/components/molecules/FtPriceConditions.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPriceConditions.vue
@@ -1,0 +1,69 @@
+<template lang="pug">
+div.space-y-2
+  ft-price-filter(
+    v-for="(condition, index) in conditions"
+    :key="index"
+    :operator="condition.operator"
+    :amount="condition.amount"
+    @update:operator="(operator) => updateOperator(index, operator)"
+    @update:amount="(amount) => updateAmount(index, amount)"
+    @remove="() => remove(index)"
+  )
+  UButton(
+    icon="i-heroicons-plus-20-solid"
+    color="gray"
+    variant="link"
+    size="xs"
+    :padded="false"
+    @click="add"
+  ) Ajouter une condition
+</template>
+
+<script lang="ts" setup>
+import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
+
+interface PriceConditionRow {
+  operator: TotalTtcOperator
+  amount: number | undefined
+}
+
+const props = defineProps<{
+  conditions: Array<PriceConditionRow>
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:conditions', value: Array<PriceConditionRow>): void
+}>()
+
+const updateOperator = (index: number, operator: TotalTtcOperator) => {
+  emit(
+    'update:conditions',
+    props.conditions.map((condition: PriceConditionRow, i: number) =>
+      i === index ? { ...condition, operator } : condition
+    )
+  )
+}
+
+const updateAmount = (index: number, amount: number | undefined) => {
+  emit(
+    'update:conditions',
+    props.conditions.map((condition: PriceConditionRow, i: number) =>
+      i === index ? { ...condition, amount } : condition
+    )
+  )
+}
+
+const remove = (index: number) => {
+  emit(
+    'update:conditions',
+    props.conditions.filter((_: PriceConditionRow, i: number) => i !== index)
+  )
+}
+
+const add = () => {
+  emit('update:conditions', [
+    ...props.conditions,
+    { operator: 'lte', amount: undefined }
+  ])
+}
+</script>

--- a/src/adapters/primary/nuxt/components/molecules/FtPriceFilter.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPriceFilter.vue
@@ -1,0 +1,63 @@
+<template lang="pug">
+div.flex.items-center.gap-2
+  USelect.w-20(
+    :model-value="operator"
+    :options="operatorOptions"
+    value-attribute="value"
+    option-attribute="label"
+    aria-label="Opérateur de comparaison du total TTC"
+    @update:model-value="operatorChanged"
+  )
+  ft-text-field.flex-grow(
+    :model-value="amount"
+    type="number"
+    min="0"
+    step="0.01"
+    placeholder="Montant en €"
+    aria-label="Montant du filtre Total TTC en euros"
+    @update:model-value="amountChanged"
+  )
+  UButton(
+    color="gray"
+    variant="link"
+    icon="i-heroicons-x-mark-20-solid"
+    :padded="false"
+    aria-label="Supprimer cette condition de prix"
+    @click.prevent="remove"
+  )
+</template>
+
+<script lang="ts" setup>
+import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
+
+defineProps<{
+  operator: TotalTtcOperator
+  amount: number | undefined
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:operator', value: TotalTtcOperator): void
+  (e: 'update:amount', value: number | undefined): void
+  (e: 'remove'): void
+}>()
+
+const operatorOptions = [
+  { value: 'lte', label: '≤' },
+  { value: 'eq', label: '=' },
+  { value: 'gte', label: '≥' }
+]
+
+const operatorChanged = (value: TotalTtcOperator) => {
+  emit('update:operator', value)
+}
+
+const amountChanged = (value: string) => {
+  const parsed = Number(value)
+  const isValid = value !== '' && value !== null && !isNaN(parsed) && parsed > 0
+  emit('update:amount', isValid ? parsed : undefined)
+}
+
+const remove = () => {
+  emit('remove')
+}
+</script>

--- a/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
+++ b/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
@@ -17,76 +17,111 @@ ft-table(
   template(#paymentStatus="{ item }")
     ft-payment-status-badge(:status="item.paymentStatus")
   template(#search)
-    div.flex.items-center.justify-center.space-x-4
-      ft-text-field.flex-grow(
-        v-model="search"
-        placeholder="Rechercher par référence, client, email"
-        for="search"
-        type='text'
-        name='search'
-        @input="searchChanged"
-      ) Rechercher une commande
-      UFormGroup.pb-4(label="Date de début" name="startDate")
-        UPopover(:popper="{ placement: 'bottom-start' }")
-          UButton(
-            icon="i-heroicons-calendar-days-20-solid"
-            :label="startDate ? format(startDate, 'd MMMM yyy', { locale: fr }) : ''"
+    div.space-y-3
+      div.flex.flex-wrap.items-center.gap-4
+        ft-text-field.flex-grow(
+          v-model="search"
+          placeholder="Rechercher par référence, client, email"
+          for="search"
+          type='text'
+          name='search'
+          @input="searchChanged"
+        ) Rechercher une commande
+        UButton(
+          icon="i-heroicons-funnel"
+          :color="showFilters ? 'primary' : 'gray'"
+          :variant="showFilters ? 'solid' : 'outline'"
+          aria-label="Afficher les filtres"
+          @click="toggleFilters"
+        )
+          span Filtres
+          UBadge.ml-2(
+            v-if="activeFiltersCount"
+            :label="String(activeFiltersCount)"
+            color="white"
+            size="xs"
           )
-            template(#trailing)
-              UButton(
-                v-show="startDate"
-                color="white"
-                variant="link"
-                icon="i-heroicons-x-mark-20-solid"
-                :padded="false"
-                @click.prevent="clearStartDate"
-              )
-          template(#panel="{ close }")
-            ft-date-picker(
-              v-model="startDate"
-              @update:model-value="startDateChanged"
-              @close="close"
+      ft-filter-chips(
+        :filters="vm.activeFilters || []"
+        @remove="removeFilter"
+        @clear-all="clearAllFilters"
+      )
+      div.grid.grid-cols-1.gap-4.rounded-lg.border.border-gray-200.p-4(
+        v-show="showFilters"
+        class="md:grid-cols-3"
+      )
+        UFormGroup(label="Date de début" name="startDate")
+          UPopover(:popper="{ placement: 'bottom-start' }")
+            UButton.w-full(
+              icon="i-heroicons-calendar-days-20-solid"
+              color="gray"
+              variant="outline"
+              :label="startDate ? format(startDate, 'd MMMM yyy', { locale: fr }) : 'Choisir une date'"
             )
-      UFormGroup.pb-4(label="Date de fin" name="endDate")
-        UPopover(:popper="{ placement: 'bottom-start' }")
-          UButton(
-            icon="i-heroicons-calendar-days-20-solid"
-            :label="endDate ? format(endDate, 'd MMMM yyy', { locale: fr }) : ''"
+              template(#trailing)
+                UButton(
+                  v-show="startDate"
+                  color="gray"
+                  variant="link"
+                  icon="i-heroicons-x-mark-20-solid"
+                  :padded="false"
+                  aria-label="Effacer la date de début"
+                  @click.prevent="clearStartDate"
+                )
+            template(#panel="{ close }")
+              ft-date-picker(
+                v-model="startDate"
+                @update:model-value="startDateChanged"
+                @close="close"
+              )
+        UFormGroup(label="Date de fin" name="endDate")
+          UPopover(:popper="{ placement: 'bottom-start' }")
+            UButton.w-full(
+              icon="i-heroicons-calendar-days-20-solid"
+              color="gray"
+              variant="outline"
+              :label="endDate ? format(endDate, 'd MMMM yyy', { locale: fr }) : 'Choisir une date'"
+            )
+              template(#trailing)
+                UButton(
+                  v-show="endDate"
+                  color="gray"
+                  variant="link"
+                  icon="i-heroicons-x-mark-20-solid"
+                  :padded="false"
+                  aria-label="Effacer la date de fin"
+                  @click.prevent="clearEndDate"
+                )
+            template(#panel="{ close }")
+              ft-date-picker(
+                v-model="endDate"
+                :is-end-date="true"
+                @update:model-value="endDateChanged"
+                @close="close"
+              )
+        UFormGroup(label="Statut" name="orderStatus")
+          ft-order-status-select(
+            v-model="orderStatus"
+            @update:model-value="orderStatusChanged"
+            @clear="clearOrderStatus"
           )
-            template(#trailing)
-              UButton(
-                v-show="endDate"
-                color="white"
-                variant="link"
-                icon="i-heroicons-x-mark-20-solid"
-                :padded="false"
-                @click.prevent="clearEndDate"
-              )
-          template(#panel="{ close }")
-            ft-date-picker(
-              v-model="endDate"
-              :is-end-date="true"
-              @update:model-value="endDateChanged"
-              @close="close"
-            )
-      UFormGroup.pb-4(label="Statut" name="orderStatus")
-        ft-order-status-select(
-          v-model="orderStatus"
-          @update:model-value="orderStatusChanged"
-          @clear="clearOrderStatus"
-        )
-      UFormGroup.pb-4(label="Statut de livraison" name="deliveryStatus")
-        ft-delivery-status-select(
-          v-model="deliveryStatus"
-          @update:model-value="deliveryStatusChanged"
-          @clear="clearDeliveryStatus"
-        )
-      UFormGroup.pb-4(label="Statut de paiement" name="paymentStatus")
-        ft-payment-status-select(
-          v-model="paymentStatus"
-          @update:model-value="paymentStatusChanged"
-          @clear="clearPaymentStatus"
-        )
+        UFormGroup(label="Statut de livraison" name="deliveryStatus")
+          ft-delivery-status-select(
+            v-model="deliveryStatus"
+            @update:model-value="deliveryStatusChanged"
+            @clear="clearDeliveryStatus"
+          )
+        UFormGroup(label="Statut de paiement" name="paymentStatus")
+          ft-payment-status-select(
+            v-model="paymentStatus"
+            @update:model-value="paymentStatusChanged"
+            @clear="clearPaymentStatus"
+          )
+        UFormGroup(label="Total TTC" name="totalTtc")
+          ft-price-conditions(
+            :conditions="totalTtcConditions"
+            @update:conditions="priceConditionsChanged"
+          )
   template(#infinite)
     InfiniteLoading(:identifier="infiniteIdentifier" @infinite="load")
       template(#complete)
@@ -95,7 +130,9 @@ ft-table(
 
 <script lang="ts" setup>
 import FtTable from '@adapters/primary/nuxt/components/molecules/FtTable.vue'
+import type { ActiveFilterVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
 import { listOrders } from '@core/usecases/order/list-orders/listOrders'
+import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
 import { searchOrders } from '@core/usecases/order/orders-searching/searchOrders'
 import { useOrderStore } from '@store/orderStore'
 import { useSearchStore } from '@store/searchStore'
@@ -109,6 +146,11 @@ import 'v3-infinite-loading/lib/style.css'
 interface InfiniteLoadingState {
   loaded: () => void
   complete: () => void
+}
+
+interface PriceConditionRow {
+  operator: TotalTtcOperator
+  amount: number | undefined
 }
 
 definePageMeta({ layout: 'main' })
@@ -162,6 +204,28 @@ const deliveryStatus = ref(
 const paymentStatus = ref(
   props.vm.value?.currentSearch?.paymentStatus || undefined
 )
+const emptyPriceCondition = (): PriceConditionRow => ({
+  operator: 'lte',
+  amount: undefined
+})
+const totalTtcConditions = ref<Array<PriceConditionRow>>([
+  emptyPriceCondition()
+])
+const showFilters = ref(false)
+
+const activeFiltersCount = computed(() => props.vm?.activeFilters?.length ?? 0)
+const isValidPriceRow = (condition: PriceConditionRow) =>
+  condition.amount != null && condition.amount > 0
+const validPriceConditions = () =>
+  totalTtcConditions.value.filter(isValidPriceRow)
+const toSearchConditions = (rows: Array<PriceConditionRow>) =>
+  rows.filter(isValidPriceRow).map((condition) => ({
+    operator: condition.operator,
+    value: Math.round((condition.amount as number) * 100)
+  }))
+const toggleFilters = () => {
+  showFilters.value = !showFilters.value
+}
 
 watch(
   () => props.vm,
@@ -183,6 +247,7 @@ const isSearchMode = () => {
       orderStatus.value !== undefined ||
       deliveryStatus.value !== undefined ||
       paymentStatus.value !== undefined ||
+      validPriceConditions().length > 0 ||
       props.initialFilters?.customerUuid
   )
 }
@@ -196,6 +261,9 @@ const dto = (partial: Record<string, any>) => {
     orderStatus: orderStatus.value,
     deliveryStatus: deliveryStatus.value,
     paymentStatus: paymentStatus.value,
+    totalTtcConditions: toSearchConditions(totalTtcConditions.value).length
+      ? toSearchConditions(totalTtcConditions.value)
+      : undefined,
     size: limit,
     from: 0,
     ...partial
@@ -301,6 +369,41 @@ const paymentStatusChanged = (stringStatus: string) => {
 
 const clearPaymentStatus = () => {
   paymentStatus.value = undefined
+  triggerSearch()
+}
+
+const priceConditionsChanged = (conditions: Array<PriceConditionRow>) => {
+  const before = JSON.stringify(toSearchConditions(totalTtcConditions.value))
+  totalTtcConditions.value = conditions
+  if (JSON.stringify(toSearchConditions(conditions)) === before) return
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(triggerSearch, debounceDelay)
+}
+
+const removeFilter = (filter: ActiveFilterVM) => {
+  if (filter.key === 'query') search.value = undefined
+  if (filter.key === 'startDate') startDate.value = undefined
+  if (filter.key === 'endDate') endDate.value = undefined
+  if (filter.key === 'orderStatus') orderStatus.value = undefined
+  if (filter.key === 'deliveryStatus') deliveryStatus.value = undefined
+  if (filter.key === 'paymentStatus') paymentStatus.value = undefined
+  if (filter.key === 'totalTtc' && filter.index !== undefined) {
+    const target = validPriceConditions()[filter.index]
+    totalTtcConditions.value = totalTtcConditions.value.filter(
+      (condition) => condition !== target
+    )
+  }
+  triggerSearch()
+}
+
+const clearAllFilters = () => {
+  search.value = undefined
+  startDate.value = undefined
+  endDate.value = undefined
+  orderStatus.value = undefined
+  deliveryStatus.value = undefined
+  paymentStatus.value = undefined
+  totalTtcConditions.value = [emptyPriceCondition()]
   triggerSearch()
 }
 

--- a/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.spec.ts
+++ b/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.spec.ts
@@ -3,6 +3,7 @@ import { DeliveryStatus } from '@core/entities/delivery'
 import { Order, OrderLineStatus, PaymentStatus } from '@core/entities/order'
 import { useOrderStore } from '@store/orderStore'
 import { useSearchStore } from '@store/searchStore'
+import { priceFormatter, timestampToLocaleString } from '@utils/formatters'
 import {
   orderNotPayed1,
   orderPrepared1,
@@ -141,6 +142,7 @@ describe('Get orders VM', () => {
         searchStore.set(key, [orderToPrepare1, orderNotPayed1])
         const expectedVM: Partial<GetOrdersVM> = {
           currentSearch: { query: 'jean' },
+          activeFilters: [{ key: 'query', label: 'Recherche : "jean"' }],
           items: [
             {
               reference: orderToPrepare1.uuid,
@@ -185,10 +187,60 @@ describe('Get orders VM', () => {
             endDate: 9234567890,
             orderStatus: OrderLineStatus.Started,
             paymentStatus: PaymentStatus.Payed
-          }
+          },
+          activeFilters: [
+            { key: 'query', label: 'Recherche : "test"' },
+            {
+              key: 'startDate',
+              label: `Depuis le ${timestampToLocaleString(1234567890, 'fr-FR')}`
+            },
+            {
+              key: 'endDate',
+              label: `Jusqu'au ${timestampToLocaleString(9234567890, 'fr-FR')}`
+            },
+            { key: 'orderStatus', label: 'Statut : En préparation' },
+            { key: 'paymentStatus', label: 'Paiement : Payé' }
+          ]
         }
         expectVMToMatch(expectedVM)
       })
+    })
+  })
+
+  describe('Active filters chips', () => {
+    it('should expose a chip for each active filter and each total condition', () => {
+      const low = 1000
+      const high = 2000
+      searchStore.setFilter(key, {
+        query: 'jean',
+        orderStatus: OrderLineStatus.Prepared,
+        totalTtcConditions: [
+          { operator: 'gte', value: low },
+          { operator: 'lte', value: high }
+        ]
+      })
+      const formatter = priceFormatter('fr-FR', 'EUR')
+      expect(getOrdersVM(key).activeFilters).toStrictEqual([
+        { key: 'query', label: 'Recherche : "jean"' },
+        { key: 'orderStatus', label: 'Statut : Préparé' },
+        {
+          key: 'totalTtc',
+          index: 0,
+          label: `Total TTC ≥ ${formatter.format(low / 100)}`
+        },
+        {
+          key: 'totalTtc',
+          index: 1,
+          label: `Total TTC ≤ ${formatter.format(high / 100)}`
+        }
+      ])
+    })
+    it('should use the search results when only the total filter is active', () => {
+      givenExistingOrders(orderToPrepare1)
+      searchStore.setFilter(key, {
+        totalTtcConditions: [{ operator: 'gte', value: 1 }]
+      })
+      expect(getOrdersVM(key).items).toStrictEqual([])
     })
   })
 
@@ -255,7 +307,8 @@ describe('Get orders VM', () => {
       hasMore: false,
       hasMoreSearch: false,
       isSearchLoading: false,
-      currentSearch: undefined
+      currentSearch: undefined,
+      activeFilters: []
     }
     expect(getOrdersVM(key)).toMatchObject({ ...emptyVM, ...expectedVM })
   }

--- a/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
+++ b/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
@@ -7,7 +7,10 @@ import {
   OrderLineStatus,
   PaymentStatus
 } from '@core/entities/order'
-import { SearchOrdersDTO } from '@core/usecases/order/orders-searching/searchOrders'
+import {
+  SearchOrdersDTO,
+  TotalTtcOperator
+} from '@core/usecases/order/orders-searching/searchOrders'
 import { useOrderStore } from '@store/orderStore'
 import { useSearchStore } from '@store/searchStore'
 import { priceFormatter, timestampToLocaleString } from '@utils/formatters'
@@ -29,6 +32,21 @@ export interface GetOrdersItemVM {
   deliveryStatus: DeliveryStatus
 }
 
+export type ActiveFilterKey =
+  | 'query'
+  | 'startDate'
+  | 'endDate'
+  | 'orderStatus'
+  | 'deliveryStatus'
+  | 'paymentStatus'
+  | 'totalTtc'
+
+export interface ActiveFilterVM {
+  key: ActiveFilterKey
+  index?: number
+  label: string
+}
+
 export interface GetOrdersVM {
   headers: Array<Header>
   items: Array<GetOrdersItemVM>
@@ -37,6 +55,7 @@ export interface GetOrdersVM {
   hasMoreSearch: boolean
   isSearchLoading: boolean
   currentSearch: SearchOrdersDTO | undefined
+  activeFilters: Array<ActiveFilterVM>
 }
 
 const headers: Array<Header> = [
@@ -112,8 +131,84 @@ const isAnyFilterActive = (filter: SearchOrdersDTO | undefined): boolean => {
       filter.orderStatus !== undefined ||
       filter.deliveryStatus !== undefined ||
       filter.paymentStatus !== undefined ||
-      filter.customerUuid
+      filter.customerUuid ||
+      filter.totalTtcConditions?.length
   )
+}
+
+const orderStatusChipLabels: Record<OrderLineStatus, string> = {
+  [OrderLineStatus.Created]: 'Crée',
+  [OrderLineStatus.Started]: 'En préparation',
+  [OrderLineStatus.Prepared]: 'Préparé',
+  [OrderLineStatus.Canceled]: 'Annulé'
+}
+
+const deliveryStatusChipLabels: Record<DeliveryStatus, string> = {
+  [DeliveryStatus.Created]: 'Crée',
+  [DeliveryStatus.Prepared]: 'Préparé',
+  [DeliveryStatus.Shipped]: 'Expédié',
+  [DeliveryStatus.Delivered]: 'Livré'
+}
+
+const paymentStatusChipLabels: Record<PaymentStatus, string> = {
+  [PaymentStatus.WaitingForPayment]: 'En attente de paiement',
+  [PaymentStatus.Payed]: 'Payé',
+  [PaymentStatus.Rejected]: 'Payment rejeté'
+}
+
+const totalTtcOperatorSymbols: Record<TotalTtcOperator, string> = {
+  lte: '≤',
+  eq: '=',
+  gte: '≥'
+}
+
+const buildActiveFilters = (
+  filter: SearchOrdersDTO | undefined
+): Array<ActiveFilterVM> => {
+  if (!filter) return []
+  const formatter = priceFormatter('fr-FR', 'EUR')
+  const activeFilters: Array<ActiveFilterVM> = []
+  if (filter.query) {
+    activeFilters.push({ key: 'query', label: `Recherche : "${filter.query}"` })
+  }
+  if (filter.startDate) {
+    activeFilters.push({
+      key: 'startDate',
+      label: `Depuis le ${timestampToLocaleString(filter.startDate, 'fr-FR')}`
+    })
+  }
+  if (filter.endDate) {
+    activeFilters.push({
+      key: 'endDate',
+      label: `Jusqu'au ${timestampToLocaleString(filter.endDate, 'fr-FR')}`
+    })
+  }
+  if (filter.orderStatus !== undefined) {
+    activeFilters.push({
+      key: 'orderStatus',
+      label: `Statut : ${orderStatusChipLabels[filter.orderStatus]}`
+    })
+  }
+  if (filter.deliveryStatus !== undefined) {
+    activeFilters.push({
+      key: 'deliveryStatus',
+      label: `Livraison : ${deliveryStatusChipLabels[filter.deliveryStatus]}`
+    })
+  }
+  if (filter.paymentStatus !== undefined) {
+    activeFilters.push({
+      key: 'paymentStatus',
+      label: `Paiement : ${paymentStatusChipLabels[filter.paymentStatus]}`
+    })
+  }
+  filter.totalTtcConditions?.forEach((condition, index) => {
+    activeFilters.push({
+      key: 'totalTtc',
+      index,
+      label: `Total TTC ${totalTtcOperatorSymbols[condition.operator]} ${formatter.format(condition.value / 100)}`
+    })
+  })
+  return activeFilters
 }
 
 export const getOrdersVM = (key: string): GetOrdersVM => {
@@ -130,6 +225,7 @@ export const getOrdersVM = (key: string): GetOrdersVM => {
     hasMore: orderStore.hasMore,
     hasMoreSearch: searchStore.hasMoreSearch(key),
     isSearchLoading: searchStore.isLoading(key),
-    currentSearch: searchFilter
+    currentSearch: searchFilter,
+    activeFilters: buildActiveFilters(searchFilter)
   }
 }

--- a/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
@@ -4,6 +4,7 @@ import {
   SearchProductsResult
 } from '@core/gateways/searchGateway'
 import '@utils/strings'
+import { computeTotalWithTaxForOrder } from '@adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM'
 import { Customer } from '@core/entities/customer'
 import {
   getDeliveryStatus,
@@ -13,7 +14,10 @@ import {
 } from '@core/entities/order'
 import { Timestamp } from '@core/types/types'
 import { SearchCustomersDTO } from '@core/usecases/customers/customer-searching/searchCustomer'
-import { SearchOrdersDTO } from '@core/usecases/order/orders-searching/searchOrders'
+import {
+  SearchOrdersDTO,
+  TotalTtcCondition
+} from '@core/usecases/order/orders-searching/searchOrders'
 import { SearchProductsFilters } from '@core/usecases/product/product-searching/searchProducts'
 import { useCustomerStore } from '@store/customerStore'
 import { useOrderStore } from '@store/orderStore'
@@ -103,13 +107,17 @@ export class FakeSearchGateway implements SearchGateway {
         dto.customerUuid !== undefined
           ? dto.customerUuid === o.customerUuid
           : true
+      const totalTtcMatch = dto.totalTtcConditions?.length
+        ? this.ordersTotalTtcMatch(o, dto.totalTtcConditions)
+        : true
       return (
         queryMatch &&
         dateMatch &&
         orderStatusMatch &&
         deliveryStatusMatch &&
         paymentStatusMatch &&
-        customerUuidMatch
+        customerUuidMatch &&
+        totalTtcMatch
       )
     })
     const from = dto.from ?? 0
@@ -127,6 +135,18 @@ export class FakeSearchGateway implements SearchGateway {
       : (order.deliveries?.[0]?.receiver?.contact?.email ?? '')
     const isEmailMatching = email ? email.includesWithoutCase(query) : false
     return isReferenceMatching || isClientNameMatching || isEmailMatching
+  }
+
+  private ordersTotalTtcMatch = (
+    order: Order,
+    conditions: Array<TotalTtcCondition>
+  ): boolean => {
+    const total = computeTotalWithTaxForOrder(order)
+    return conditions.every(({ operator, value }) => {
+      if (operator === 'lte') return total <= value
+      if (operator === 'gte') return total >= value
+      return Math.abs(total - value) < 1
+    })
   }
 
   private ordersDateMatch = (

--- a/src/adapters/secondary/search-gateways/RealSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/RealSearchGateway.ts
@@ -85,6 +85,7 @@ export class RealSearchGateway extends RealGateway implements SearchGateway {
         dto.deliveryStatus !== undefined
           ? deliveryStatusMap[dto.deliveryStatus]
           : undefined,
+      totalTtcConditions: dto.totalTtcConditions,
       limit: dto.size,
       offset: dto.from
     }

--- a/src/core/usecases/order/orders-searching/searchOrders.spec.ts
+++ b/src/core/usecases/order/orders-searching/searchOrders.spec.ts
@@ -1,3 +1,4 @@
+import { computeTotalWithTaxForOrder } from '@adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM'
 import { FakeSearchGateway } from '@adapters/secondary/search-gateways/FakeSearchGateway'
 import { DeliveryStatus } from '@core/entities/delivery'
 import { Order, OrderLineStatus, PaymentStatus } from '@core/entities/order'
@@ -225,6 +226,77 @@ describe('Search orders', () => {
         expectSearchResultToEqual(elodieDurandOrder2)
       })
     })
+    describe('Filter on total TTC', () => {
+      const expensiveOrder: Order = {
+        ...orderToPrepare1,
+        uuid: 'EXPENSIVE',
+        lines: [
+          {
+            ...orderToPrepare1.lines[0],
+            expectedQuantity: orderToPrepare1.lines[0].expectedQuantity + 1
+          }
+        ]
+      }
+      beforeEach(() => {
+        givenExistingOrders(orderToPrepare1, expensiveOrder)
+      })
+      it('should keep orders with total lower or equal to the value', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'lte',
+            value: computeTotalWithTaxForOrder(orderToPrepare1)
+          }
+        ]
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(orderToPrepare1)
+      })
+      it('should keep orders with total greater or equal to the value', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'gte',
+            value: computeTotalWithTaxForOrder(expensiveOrder)
+          }
+        ]
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(expensiveOrder)
+      })
+      it('should keep orders with total equal to the value', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'eq',
+            value: computeTotalWithTaxForOrder(orderToPrepare1)
+          }
+        ]
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(orderToPrepare1)
+      })
+      it('should keep orders matching all conditions combined (between)', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'gte',
+            value: computeTotalWithTaxForOrder(orderToPrepare1)
+          },
+          {
+            operator: 'lte',
+            value: computeTotalWithTaxForOrder(expensiveOrder) - 1
+          }
+        ]
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(orderToPrepare1)
+      })
+      it('should combine the total filter with the query filter', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'gte',
+            value: computeTotalWithTaxForOrder(orderToPrepare1)
+          }
+        ]
+        dto.query = orderToPrepare1.uuid
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(orderToPrepare1)
+      })
+    })
+
     describe('Pagination', () => {
       beforeEach(() => {
         givenExistingOrders(orderToPrepare1, orderPrepared1, orderNotPayed1)

--- a/src/core/usecases/order/orders-searching/searchOrders.ts
+++ b/src/core/usecases/order/orders-searching/searchOrders.ts
@@ -9,6 +9,13 @@ export interface SearchDTO {
   minimumQueryLength?: number
 }
 
+export type TotalTtcOperator = 'lte' | 'eq' | 'gte'
+
+export interface TotalTtcCondition {
+  operator: TotalTtcOperator
+  value: number
+}
+
 export interface SearchOrdersDTO extends SearchDTO {
   startDate?: Timestamp
   endDate?: Timestamp
@@ -16,6 +23,7 @@ export interface SearchOrdersDTO extends SearchDTO {
   deliveryStatus?: DeliveryStatus
   paymentStatus?: PaymentStatus
   customerUuid?: UUID
+  totalTtcConditions?: Array<TotalTtcCondition>
   size?: number
   from?: number
 }


### PR DESCRIPTION
## What

Adds a **Total TTC** filter on the orders table with operators `≤ / = / ≥` that can be **combined as multiple conditions (AND)** — e.g. orders between 10 and 20 €. Also reworks the cluttered filters area.

## UX

- Search bar stays visible; a **"Filtres (n)"** button opens a grouped panel (dates, statuses, Total TTC).
- **Active-filter chips** below the bar — one per condition — with one-click removal + "Tout effacer".
- Total TTC = repeatable rows (operator + amount + ✕) with **"Ajouter une condition"**.
- Status selects made full-width to align with the date / Total TTC fields.

## Behaviour

- Filtering is done at the **DB level** (backend search); the filter uses the **same rounding** as the displayed total, so results match the column to the cent.
- A search is triggered **only when the set of valid conditions actually changes** (adding an empty row or changing an operator on an empty field does not refresh). Amount input is debounced (300 ms).
- Filters remain in Pinia (no URL persistence).

## Components

New `FtPriceConditions`, `FtPriceFilter`, `FtFilterChips`. VM exposes `activeFilters` (one chip per condition).

## Tests

`getOrdersVM.spec.ts` (chips per condition) and `searchOrders.spec.ts` (≤ / = / ≥ + "between" via the Fake gateway using the display formula). Full frontend suite green (2433). Verified end-to-end in a real browser (rounding match, between, chip removal, no-refresh on empty edits).

Depends on phardev/ecommerce-backend#49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)