### PR TITLE
feat: sort the products list by stock

### DIFF
--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -41,7 +41,8 @@
     "expandAll": "Voir tout",
     "collapseAll": "Cacher tout",
     "active": "Actif",
-    "inactive": "Inactif"
+    "inactive": "Inactif",
+    "sortBy": "Trier par {name}"
   },
   "categories": {
     "status": {

--- a/src/adapters/primary/nuxt/components/molecules/FtTable.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtTable.vue
@@ -26,7 +26,21 @@
               :key="headerIndex"
               :class="[headerIndex === 0 ? 'pl-4 pr-3 sm:pl-6' : 'px-3 lg:table-cell', 'text-left text-sm font-semibold text-default py-3.5']"
               scope='col'
-            ) {{ header.name }}
+              :aria-sort="ariaSort(header)"
+            )
+              button.inline-flex.items-center.gap-1.rounded(
+                v-if="header.sortable"
+                type="button"
+                class="cursor-pointer transition-colors duration-200 hover:text-colored focus:outline-none focus-visible:ring-2 focus-visible:ring-colored"
+                :aria-label="$t('common.sortBy', { name: header.name })"
+                @click.stop="sortBy(header.value)"
+              )
+                span {{ header.name }}
+                UIcon.h-4.w-4(
+                  :name="sortIcon(header)"
+                  :class="isSorted(header) ? 'text-colored' : 'text-gray-400'"
+                )
+              template(v-else) {{ header.name }}
         tbody(v-if="isLoading && items.length === 0")
           tr(v-for="i in 5" :key="i")
             td(v-if="selectable" class="relative w-12 px-6 sm:w-16 sm:px-8")
@@ -92,6 +106,10 @@ const props = defineProps({
     default: () => {
       return false
     }
+  },
+  sort: {
+    type: Object as PropType<{ field: string; direction: 'asc' | 'desc' }>,
+    default: undefined
   }
 })
 
@@ -104,7 +122,27 @@ const emit = defineEmits<{
   (e: 'clicked', value: any): void
   (e: 'item-selected', value: any): void
   (e: 'select-all', value: Array<any>): void
+  (e: 'sort', value: string): void
 }>()
+
+const isSorted = (header: any) => props.sort?.field === header.value
+
+const ariaSort = (header: any) => {
+  if (!header.sortable) return undefined
+  if (!isSorted(header)) return 'none'
+  return props.sort?.direction === 'asc' ? 'ascending' : 'descending'
+}
+
+const sortIcon = (header: any) => {
+  if (!isSorted(header)) return 'i-heroicons-chevron-up-down-20-solid'
+  return props.sort?.direction === 'asc'
+    ? 'i-heroicons-chevron-up-20-solid'
+    : 'i-heroicons-chevron-down-20-solid'
+}
+
+const sortBy = (value: string) => {
+  emit('sort', value)
+}
 
 const indeterminate = computed(() => {
   return (

--- a/src/adapters/primary/nuxt/pages/products/index.vue
+++ b/src/adapters/primary/nuxt/pages/products/index.vue
@@ -9,9 +9,11 @@
     :is-loading="productsVM.isLoading"
     :selectable="true"
     :selection="productSelector.get()"
+    :sort="productsVM.sort"
     @item-selected="productSelector.toggleSelect"
     @select-all="productSelector.toggleSelectAll"
     @clicked="productSelected"
+    @sort="stockSortChanged"
   )
     template(#title) Produits
     template(#search)
@@ -105,7 +107,7 @@ const productsVM = computed(() => {
 })
 
 const load = async ($state: InfiniteLoadingState) => {
-  if (!search.value && !productStatus.value) {
+  if (!search.value && !productStatus.value && !stockSort.value) {
     await listProducts(limit, offset, productGateway)
     offset += limit
     if (productsVM.value.hasMore) {
@@ -114,7 +116,7 @@ const load = async ($state: InfiniteLoadingState) => {
       $state.complete()
     }
   } else {
-    if (productsVM.value.isSearchLoading) {
+    if (productsVM.value.isLoading) {
       return
     }
     if (!productsVM.value.hasMoreSearch) {
@@ -143,6 +145,9 @@ const load = async ($state: InfiniteLoadingState) => {
 
 const search = ref(productsVM.value.currentSearch?.query)
 const productStatus = ref(productsVM.value.currentSearch?.status)
+const stockSort = ref<'asc' | 'desc' | undefined>(
+  productsVM.value.currentSearch?.sort?.direction
+)
 const minimumQueryLength = 3
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -157,8 +162,28 @@ const buildFilters = (partial: {
     query: search.value,
     status: productStatus.value,
     size: limit,
+    sort: stockSort.value
+      ? { field: 'availableStock', direction: stockSort.value }
+      : undefined,
     ...partial
   }
+}
+
+const nextStockSort = (current: 'asc' | 'desc' | undefined) => {
+  if (current === undefined) return 'asc'
+  if (current === 'asc') return 'desc'
+  return undefined
+}
+
+const stockSortChanged = (field: string) => {
+  if (field !== 'availableStock') return
+  stockSort.value = nextStockSort(stockSort.value)
+  searchOffset = 0
+  searchProducts(
+    String(routeName),
+    buildFilters({ from: 0 }),
+    useSearchGateway()
+  )
 }
 
 const searchChanged = (e: any) => {

--- a/src/adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM.ts
+++ b/src/adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM.ts
@@ -27,6 +27,7 @@ export interface GetPreparationsItemVM {
 export interface Header {
   name: string
   value: string
+  sortable?: boolean
 }
 
 interface GetPreparationsGroupVM {

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
@@ -56,7 +56,8 @@ describe('Get products VM', () => {
     },
     {
       name: 'Stock',
-      value: 'availableStock'
+      value: 'availableStock',
+      sortable: true
     },
     {
       name: 'Statut',
@@ -272,6 +273,22 @@ describe('Get products VM', () => {
           expectVMToMatch(expectedVM)
         })
       })
+      describe('There is a sort', () => {
+        beforeEach(() => {
+          searchStore.setFilter(key, {
+            sort: { field: 'availableStock', direction: 'asc' }
+          })
+        })
+        it('should expose the current sort', () => {
+          expectedVM = {
+            currentSearch: {
+              sort: { field: 'availableStock', direction: 'asc' }
+            },
+            sort: { field: 'availableStock', direction: 'asc' }
+          }
+          expectVMToMatch(expectedVM)
+        })
+      })
       describe('Search performed but no results found', () => {
         beforeEach(() => {
           productStore.items = [dolodentListItem, ultraLevureListItem]
@@ -343,10 +360,10 @@ describe('Get products VM', () => {
       }
       expectVMToMatch(expectedVM)
     })
-    it('should expose isSearchLoading from search store', () => {
+    it('should be loading while a search is in progress', () => {
       searchStore.startLoading(key)
       expectedVM = {
-        isSearchLoading: true
+        isLoading: true
       }
       expectVMToMatch(expectedVM)
     })
@@ -359,9 +376,9 @@ describe('Get products VM', () => {
       hasMore: false,
       hasMoreSearch: false,
       currentSearch: undefined,
+      sort: undefined,
       searchError: undefined,
-      isLoading: false,
-      isSearchLoading: false
+      isLoading: false
     }
     expect(getProductsVM(key)).toMatchObject({ ...emptyVM, ...expectedVM })
   }

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
@@ -2,7 +2,10 @@ import { Header } from '@adapters/primary/view-models/preparations/get-orders-to
 import { ProductStatus } from '@core/entities/product'
 import { UUID } from '@core/types/types'
 import { ProductListItem } from '@core/usecases/product/product-listing/productListItem'
-import { SearchProductsFilters } from '@core/usecases/product/product-searching/searchProducts'
+import {
+  ProductsSort,
+  SearchProductsFilters
+} from '@core/usecases/product/product-searching/searchProducts'
 import { useProductStore } from '@store/productStore'
 import { useSearchStore } from '@store/searchStore'
 import { priceFormatter } from '@utils/formatters'
@@ -27,21 +30,20 @@ export interface GetProductsVM {
   hasMore: boolean
   hasMoreSearch: boolean
   currentSearch: SearchProductsFilters | undefined
+  sort: ProductsSort | undefined
   searchError: string | undefined
   isLoading: boolean
-  isSearchLoading: boolean
 }
 
 export const getProductsVM = (key: string): GetProductsVM => {
   const productStore = useProductStore()
-  const isLoading = productStore.isLoading
   const searchStore = useSearchStore()
   const allProducts = productStore.items
   const searchResult = searchStore.get(key)
   const searchFilter = searchStore.getFilter(key)
   const searchError = searchStore.getError(key)
   const hasMoreSearch = searchStore.hasMoreSearch(key)
-  const isSearchLoading = searchStore.isLoading(key)
+  const isLoading = productStore.isLoading || searchStore.isLoading(key)
   const products = searchResult !== undefined ? searchResult : allProducts
   const formatter = priceFormatter('fr-FR', 'EUR')
   const headers: Array<Header> = [
@@ -75,7 +77,8 @@ export const getProductsVM = (key: string): GetProductsVM => {
     },
     {
       name: 'Stock',
-      value: 'availableStock'
+      value: 'availableStock',
+      sortable: true
     },
     {
       name: 'Statut',
@@ -107,12 +110,12 @@ export const getProductsVM = (key: string): GetProductsVM => {
       }
     }),
     currentSearch: searchFilter,
+    sort: searchFilter?.sort,
     searchError: searchError
       ? 'Veuillez saisir au moins 3 caractères pour lancer la recherche.'
       : undefined,
     hasMore: productStore.hasMore.valueOf(),
     hasMoreSearch,
-    isLoading,
-    isSearchLoading
+    isLoading
   }
 }

--- a/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
@@ -57,11 +57,13 @@ export class FakeSearchGateway implements SearchGateway {
       if (filters.status) {
         return p.status === filters.status
       }
+      return true
     })
-    const total = filtered.length
+    const sorted = this.sortProducts(filtered, filters)
+    const total = sorted.length
     const from = filters.from ?? 0
     const size = filters.size ?? 25
-    const items = filtered.slice(from, from + size)
+    const items = sorted.slice(from, from + size)
     const page = Math.floor(from / size) + 1
     const totalPages = Math.ceil(total / size)
     const hasMore = items.length === size && total > from + size
@@ -74,6 +76,24 @@ export class FakeSearchGateway implements SearchGateway {
         totalPages
       },
       hasMore
+    })
+  }
+
+  private sortProducts(
+    products: Array<Product>,
+    filters: SearchProductsFilters
+  ): Array<Product> {
+    if (!filters.sort) {
+      return products
+    }
+    const { field, direction } = filters.sort
+    const factor = direction === 'asc' ? 1 : -1
+    return [...products].sort((a: any, b: any) => {
+      const primary =
+        typeof a[field] === 'number' && typeof b[field] === 'number'
+          ? (a[field] - b[field]) * factor
+          : String(a[field]).localeCompare(String(b[field])) * factor
+      return primary !== 0 ? primary : a.uuid.localeCompare(b.uuid)
     })
   }
 

--- a/src/core/usecases/product/product-searching/searchProducts.spec.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.spec.ts
@@ -254,6 +254,25 @@ describe('Search products', () => {
         })
       })
     })
+    describe('Sort filter', () => {
+      beforeEach(() => {
+        searchGateway.feedWith(dolodent, chamomilla, calmosine)
+      })
+      describe('Sort only, without query or status', () => {
+        beforeEach(async () => {
+          givenSortIs({ field: 'availableStock', direction: 'asc' })
+          await whenSearchForProducts()
+        })
+        it('should search the whole catalog sorted by stock', () => {
+          expectSearchResultToEqual(chamomilla, calmosine, dolodent)
+        })
+        it('should save the sort filter', () => {
+          expectCurrentFiltersToEqual({
+            sort: { field: 'availableStock', direction: 'asc' }
+          })
+        })
+      })
+    })
     describe('Status filter', () => {
       beforeEach(() => {
         searchGateway.feedWith(dolodent, ultraLevure, chamomilla)
@@ -308,6 +327,15 @@ describe('Search products', () => {
       givenQueryIs('')
       await whenSearchForProducts()
       expectLoadingToBe(false)
+    })
+
+    it('should clear previous results while a fresh search is loading', async () => {
+      givenQueryIs('cha')
+      await whenSearchForProducts()
+      givenQueryIs('dol')
+      const promise = whenSearchForProducts()
+      expectSearchResultToEqual()
+      await promise
     })
   })
 
@@ -396,6 +424,10 @@ describe('Search products', () => {
 
   const givenFromIs = (from: number) => {
     filters.from = from
+  }
+
+  const givenSortIs = (sort: SearchProductsFilters['sort']) => {
+    filters.sort = sort
   }
 
   const whenSearchForProducts = async () => {

--- a/src/core/usecases/product/product-searching/searchProducts.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.ts
@@ -2,12 +2,18 @@ import { ProductStatus } from '@core/entities/product'
 import { SearchGateway } from '@core/gateways/searchGateway'
 import { useSearchStore } from '@store/searchStore'
 
+export interface ProductsSort {
+  field: string
+  direction: 'asc' | 'desc'
+}
+
 export interface SearchProductsFilters {
   query?: string
   minimumQueryLength?: number
   status?: ProductStatus
   size?: number
   from?: number
+  sort?: ProductsSort
 }
 
 export const searchProducts = async (
@@ -26,14 +32,17 @@ export const searchProducts = async (
     searchStore.set(key, [])
     searchStore.setPagination(key, { total: 0, from: 0, hasMore: false })
     searchStore.endLoading(key)
-  } else if (!filters.query && !filters.status) {
+  } else if (!filters.query && !filters.status && !filters.sort) {
     searchStore.clear(key)
     searchStore.setError(key, undefined)
     searchStore.endLoading(key)
   } else {
     searchStore.startLoading(key)
-    const searchResult = await searchGateway.searchProducts(filters)
     const isAppending = (filters.from ?? 0) > 0
+    if (!isAppending) {
+      searchStore.set(key, [])
+    }
+    const searchResult = await searchGateway.searchProducts(filters)
     if (isAppending) {
       searchStore.append(key, searchResult.items)
     } else {


### PR DESCRIPTION
## What

Adds stock sorting to the admin products list. Resolves the frontend part of issue #146.

## UX

- The **"Stock"** column header is now clickable and cycles **off → ascending → descending → off** (ascending first, so out-of-stock items surface first).
- A chevron shows sortability and current direction (`chevron-up-down` → `up` → `down`); `aria-sort` on the `th` and a translated `aria-label` on the button keep it accessible and keyboard-operable.
- Sort state persists in the Pinia search filter (no URL persistence), consistent with the existing search/status filters.

## How

- Sorting routes through the existing product **search** path (ElasticSearch), the only path that already combines query + status + pagination server-side — so it sorts the whole catalog and combines with the other filters. A sort-only request (no query/status) now triggers a search instead of clearing.
- `FtTable` gains a generic sortable header: a `sortable` flag on the header + a `sort` prop, emitting a `sort` event. `getProductsVM` marks the Stock header sortable and exposes the current `sort`.
- Loading: a fresh search clears results while loading so the table shows its skeleton; the view model exposes a single mode-aware `isLoading` (replacing the separate `isSearchLoading`).

## Tests & verification

VM and usecase specs added (sortable header, current sort, sort-only search, clear-while-loading). Full suite green (`TZ=UTC pnpm test run`), `vue-tsc` and Biome clean. Verified end-to-end in the browser with Playwright: asc/desc/off cycle, stable tie-break on equal stock, and combination with a search filter.

Requires backend: ecommerce-backend#50

🤖 Generated with [Claude Code](https://claude.com/claude-code)