### PR TITLE
feat(#149): sort the products list by price (HT/TTC)

### DIFF
--- a/src/adapters/primary/nuxt/pages/products/index.vue
+++ b/src/adapters/primary/nuxt/pages/products/index.vue
@@ -13,7 +13,7 @@
     @item-selected="productSelector.toggleSelect"
     @select-all="productSelector.toggleSelectAll"
     @clicked="productSelected"
-    @sort="stockSortChanged"
+    @sort="sortChanged"
   )
     template(#title) Produits
     template(#search)
@@ -58,6 +58,7 @@ import { getProductsVM } from '@adapters/primary/view-models/products/get-produc
 import type { ProductStatus } from '@core/entities/product'
 import { listCategories } from '@core/usecases/categories/list-categories/listCategories'
 import { listProducts } from '@core/usecases/product/product-listing/listProducts'
+import type { ProductsSort } from '@core/usecases/product/product-searching/searchProducts'
 import { searchProducts } from '@core/usecases/product/product-searching/searchProducts'
 import { useCategoryStore } from '@store/categoryStore'
 import { dents, diarrhee } from '@utils/testData/categories'
@@ -107,7 +108,7 @@ const productsVM = computed(() => {
 })
 
 const load = async ($state: InfiniteLoadingState) => {
-  if (!search.value && !productStatus.value && !stockSort.value) {
+  if (!search.value && !productStatus.value && !sort.value) {
     await listProducts(limit, offset, productGateway)
     offset += limit
     if (productsVM.value.hasMore) {
@@ -145,9 +146,7 @@ const load = async ($state: InfiniteLoadingState) => {
 
 const search = ref(productsVM.value.currentSearch?.query)
 const productStatus = ref(productsVM.value.currentSearch?.status)
-const stockSort = ref<'asc' | 'desc' | undefined>(
-  productsVM.value.currentSearch?.sort?.direction
-)
+const sort = ref<ProductsSort | undefined>(productsVM.value.currentSearch?.sort)
 const minimumQueryLength = 3
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -162,22 +161,22 @@ const buildFilters = (partial: {
     query: search.value,
     status: productStatus.value,
     size: limit,
-    sort: stockSort.value
-      ? { field: 'availableStock', direction: stockSort.value }
-      : undefined,
+    sort: sort.value,
     ...partial
   }
 }
 
-const nextStockSort = (current: 'asc' | 'desc' | undefined) => {
-  if (current === undefined) return 'asc'
-  if (current === 'asc') return 'desc'
+const nextSort = (
+  current: ProductsSort | undefined,
+  field: string
+): ProductsSort | undefined => {
+  if (!current || current.field !== field) return { field, direction: 'asc' }
+  if (current.direction === 'asc') return { field, direction: 'desc' }
   return undefined
 }
 
-const stockSortChanged = (field: string) => {
-  if (field !== 'availableStock') return
-  stockSort.value = nextStockSort(stockSort.value)
+const sortChanged = (field: string) => {
+  sort.value = nextSort(sort.value, field)
   searchOffset = 0
   searchProducts(
     String(routeName),

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
@@ -48,11 +48,13 @@ describe('Get products VM', () => {
     },
     {
       name: 'Prix HT',
-      value: 'priceWithoutTax'
+      value: 'priceWithoutTax',
+      sortable: true
     },
     {
       name: 'Prix TTC',
-      value: 'priceWithTax'
+      value: 'priceWithTax',
+      sortable: true
     },
     {
       name: 'Stock',
@@ -285,6 +287,22 @@ describe('Get products VM', () => {
               sort: { field: 'availableStock', direction: 'asc' }
             },
             sort: { field: 'availableStock', direction: 'asc' }
+          }
+          expectVMToMatch(expectedVM)
+        })
+      })
+      describe('There is a price sort', () => {
+        beforeEach(() => {
+          searchStore.setFilter(key, {
+            sort: { field: 'priceWithTax', direction: 'desc' }
+          })
+        })
+        it('should expose the current sort', () => {
+          expectedVM = {
+            currentSearch: {
+              sort: { field: 'priceWithTax', direction: 'desc' }
+            },
+            sort: { field: 'priceWithTax', direction: 'desc' }
           }
           expectVMToMatch(expectedVM)
         })

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
@@ -69,11 +69,13 @@ export const getProductsVM = (key: string): GetProductsVM => {
     },
     {
       name: 'Prix HT',
-      value: 'priceWithoutTax'
+      value: 'priceWithoutTax',
+      sortable: true
     },
     {
       name: 'Prix TTC',
-      value: 'priceWithTax'
+      value: 'priceWithTax',
+      sortable: true
     },
     {
       name: 'Stock',

--- a/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
@@ -21,6 +21,7 @@ import {
 import { SearchProductsFilters } from '@core/usecases/product/product-searching/searchProducts'
 import { useCustomerStore } from '@store/customerStore'
 import { useOrderStore } from '@store/orderStore'
+import { addTaxToPrice } from '@utils/price'
 
 export class FakeSearchGateway implements SearchGateway {
   private items: Array<any> = []
@@ -89,12 +90,21 @@ export class FakeSearchGateway implements SearchGateway {
     const { field, direction } = filters.sort
     const factor = direction === 'asc' ? 1 : -1
     return [...products].sort((a: any, b: any) => {
+      const aValue = this.sortValue(a, field)
+      const bValue = this.sortValue(b, field)
       const primary =
-        typeof a[field] === 'number' && typeof b[field] === 'number'
-          ? (a[field] - b[field]) * factor
-          : String(a[field]).localeCompare(String(b[field])) * factor
+        typeof aValue === 'number' && typeof bValue === 'number'
+          ? (aValue - bValue) * factor
+          : String(aValue).localeCompare(String(bValue)) * factor
       return primary !== 0 ? primary : a.uuid.localeCompare(b.uuid)
     })
+  }
+
+  private sortValue(product: any, field: string): unknown {
+    if (field === 'priceWithTax') {
+      return addTaxToPrice(product.priceWithoutTax, product.percentTaxRate)
+    }
+    return product[field]
   }
 
   indexProducts(limit: number, offset: number): Promise<number> {

--- a/src/core/usecases/product/product-searching/searchProducts.spec.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.spec.ts
@@ -272,6 +272,30 @@ describe('Search products', () => {
           })
         })
       })
+      describe('Sort by priceWithoutTax', () => {
+        it('should sort the whole catalog by price HT ascending', async () => {
+          givenSortIs({ field: 'priceWithoutTax', direction: 'asc' })
+          await whenSearchForProducts()
+          expectSearchResultToEqual(dolodent, chamomilla, calmosine)
+        })
+        it('should sort the whole catalog by price HT descending', async () => {
+          givenSortIs({ field: 'priceWithoutTax', direction: 'desc' })
+          await whenSearchForProducts()
+          expectSearchResultToEqual(calmosine, chamomilla, dolodent)
+        })
+      })
+      describe('Sort by priceWithTax', () => {
+        it('should sort the whole catalog by price TTC ascending', async () => {
+          givenSortIs({ field: 'priceWithTax', direction: 'asc' })
+          await whenSearchForProducts()
+          expectSearchResultToEqual(dolodent, chamomilla, calmosine)
+        })
+        it('should sort the whole catalog by price TTC descending', async () => {
+          givenSortIs({ field: 'priceWithTax', direction: 'desc' })
+          await whenSearchForProducts()
+          expectSearchResultToEqual(calmosine, chamomilla, dolodent)
+        })
+      })
     })
     describe('Status filter', () => {
       beforeEach(() => {


### PR DESCRIPTION
## Summary
- Make the **Prix HT** and **Prix TTC** column headers sortable, generalizing the stock sort (#146) into a single active sort across `availableStock`, `priceWithoutTax`, `priceWithTax`.
- Clicking a header cycles off → asc → desc → off; clicking another column switches the active sort to it (asc first). One sort active at a time.
- Sorting stays server-side via the product search, so it covers the whole catalog and combines with the search + status filters. Sort state lives in the Pinia search filter (no URL persistence, consistent with existing filters).
- `FakeSearchGateway` computes `priceWithTax` on the fly via `addTaxToPrice` (the front entity only stores `priceWithoutTax` + `percentTaxRate`; TTC is derived in the VM).

## Related Issue
Part of #149 (admin frontend; backend in ecommerce-backend)

## Test Plan
- [x] Unit tests pass (`TZ=UTC pnpm test run`, 2442 tests)
- [x] `vue-tsc --noEmit` + `lint` clean
- [x] Manual (Playwright): HT asc/desc, TTC asc/desc, column switch resets the other, third click clears; stock sort unaffected (#146); combines with search filter

## Screenshots
Search "Product" + Prix HT ascending (combined filter + sort) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)