### PR TITLE
feat(#145): add price TTC filter to the products table

### DIFF
--- a/src/adapters/primary/nuxt/components/molecules/FtFilterChips.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtFilterChips.vue
@@ -19,7 +19,7 @@ div.flex.flex-wrap.items-center.gap-2(v-if="filters.length")
 </template>
 
 <script lang="ts" setup>
-import type { ActiveFilterVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
+import type { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 
 defineProps<{
   filters: Array<ActiveFilterVM>

--- a/src/adapters/primary/nuxt/components/molecules/FtPriceConditions.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPriceConditions.vue
@@ -20,10 +20,10 @@ div.space-y-2
 </template>
 
 <script lang="ts" setup>
-import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
+import type { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 
 interface PriceConditionRow {
-  operator: TotalTtcOperator
+  operator: PriceFilterOperator
   amount: number | undefined
 }
 
@@ -35,7 +35,7 @@ const emit = defineEmits<{
   (e: 'update:conditions', value: Array<PriceConditionRow>): void
 }>()
 
-const updateOperator = (index: number, operator: TotalTtcOperator) => {
+const updateOperator = (index: number, operator: PriceFilterOperator) => {
   emit(
     'update:conditions',
     props.conditions.map((condition: PriceConditionRow, i: number) =>

--- a/src/adapters/primary/nuxt/components/molecules/FtPriceFilter.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPriceFilter.vue
@@ -1,23 +1,24 @@
 <template lang="pug">
 div.flex.items-center.gap-2
-  USelect.w-20(
+  USelect.w-20.shrink-0(
     :model-value="operator"
     :options="operatorOptions"
     value-attribute="value"
     option-attribute="label"
-    aria-label="Opérateur de comparaison du total TTC"
+    size="lg"
+    aria-label="Opérateur de comparaison du prix"
     @update:model-value="operatorChanged"
   )
-  ft-text-field.flex-grow(
+  ft-text-field.min-w-0.flex-1(
     :model-value="amount"
     type="number"
     min="0"
     step="0.01"
     placeholder="Montant en €"
-    aria-label="Montant du filtre Total TTC en euros"
+    aria-label="Montant du filtre en euros"
     @update:model-value="amountChanged"
   )
-  UButton(
+  UButton.shrink-0(
     color="gray"
     variant="link"
     icon="i-heroicons-x-mark-20-solid"
@@ -28,15 +29,15 @@ div.flex.items-center.gap-2
 </template>
 
 <script lang="ts" setup>
-import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
+import type { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 
 defineProps<{
-  operator: TotalTtcOperator
+  operator: PriceFilterOperator
   amount: number | undefined
 }>()
 
 const emit = defineEmits<{
-  (e: 'update:operator', value: TotalTtcOperator): void
+  (e: 'update:operator', value: PriceFilterOperator): void
   (e: 'update:amount', value: number | undefined): void
   (e: 'remove'): void
 }>()
@@ -47,7 +48,7 @@ const operatorOptions = [
   { value: 'gte', label: '≥' }
 ]
 
-const operatorChanged = (value: TotalTtcOperator) => {
+const operatorChanged = (value: PriceFilterOperator) => {
   emit('update:operator', value)
 }
 

--- a/src/adapters/primary/nuxt/components/molecules/FtProductStatusSelect.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtProductStatusSelect.vue
@@ -1,8 +1,9 @@
 <template lang="pug">
-div.flex.items-center.justify-center
+div.flex.items-center.gap-1
   USelectMenu.w-44(
     v-model="model"
     :options="options"
+    size="lg"
   )
     template(#label)
       ft-product-status-badge(v-if="model !== undefined" :status="model")

--- a/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
+++ b/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
@@ -130,7 +130,7 @@ ft-table(
 
 <script lang="ts" setup>
 import FtTable from '@adapters/primary/nuxt/components/molecules/FtTable.vue'
-import type { ActiveFilterVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
+import type { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 import { listOrders } from '@core/usecases/order/list-orders/listOrders'
 import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
 import { searchOrders } from '@core/usecases/order/orders-searching/searchOrders'

--- a/src/adapters/primary/nuxt/pages/products/index.vue
+++ b/src/adapters/primary/nuxt/pages/products/index.vue
@@ -17,23 +17,38 @@
   )
     template(#title) Produits
     template(#search)
-      .flex.items-center.justify-center.space-x-4
-        .flex-grow
-          ft-text-field(
-            v-model="search"
-            placeholder="Rechercher par nom, référence, catégorie, laboratoire"
-            for="search"
-            type='text'
-            name='search'
-            @input="searchChanged"
-          ) Rechercher un produit
-          p.warning.text-warning(v-if="productsVM.searchError") {{ productsVM.searchError }}
-        UFormGroup.pb-4(label="Statut" name="productStatus")
-          ft-product-status-select(
-            v-model="productStatus"
-            @update:model-value="productStatusChanged"
-            @clear="clearProductStatus"
+      div.space-y-3
+        div.flex.flex-wrap.items-start.gap-4
+          UFormGroup(
+            class="flex-1 min-w-[16rem] max-w-md"
+            label="Recherche"
+            name="search"
           )
+            ft-text-field(
+              v-model="search"
+              placeholder="Rechercher par nom, référence, catégorie, laboratoire"
+              for="search"
+              type='text'
+              name='search'
+              @input="searchChanged"
+            )
+            p.warning.text-warning(v-if="productsVM.searchError") {{ productsVM.searchError }}
+          UFormGroup.shrink-0(label="Statut" name="productStatus")
+            ft-product-status-select(
+              v-model="productStatus"
+              @update:model-value="productStatusChanged"
+              @clear="clearProductStatus"
+            )
+          UFormGroup.shrink-0(class="w-72" label="Prix TTC" name="priceTtc")
+            ft-price-conditions(
+              :conditions="priceTtcConditions"
+              @update:conditions="priceConditionsChanged"
+            )
+        ft-filter-chips(
+          :filters="productsVM.activeFilters || []"
+          @remove="removeFilter"
+          @clear-all="clearAllFilters"
+        )
     template(#name="{ item }")
       .font-medium.text-default {{ item.name }}
     template(#infinite)
@@ -55,11 +70,13 @@
 
 <script lang="ts" setup>
 import { getProductsVM } from '@adapters/primary/view-models/products/get-products/getProductsVM'
+import type { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 import type { ProductStatus } from '@core/entities/product'
 import { listCategories } from '@core/usecases/categories/list-categories/listCategories'
 import { listProducts } from '@core/usecases/product/product-listing/listProducts'
 import type { ProductsSort } from '@core/usecases/product/product-searching/searchProducts'
 import { searchProducts } from '@core/usecases/product/product-searching/searchProducts'
+import type { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 import { useCategoryStore } from '@store/categoryStore'
 import { dents, diarrhee } from '@utils/testData/categories'
 import InfiniteLoading from 'v3-infinite-loading'
@@ -73,6 +90,11 @@ import { useSelection } from '../../composables/useSelection'
 interface InfiniteLoadingState {
   loaded: () => void
   complete: () => void
+}
+
+interface PriceConditionRow {
+  operator: PriceFilterOperator
+  amount: number | undefined
 }
 
 definePageMeta({ layout: 'main' })
@@ -108,7 +130,12 @@ const productsVM = computed(() => {
 })
 
 const load = async ($state: InfiniteLoadingState) => {
-  if (!search.value && !productStatus.value && !sort.value) {
+  if (
+    !search.value &&
+    !productStatus.value &&
+    !sort.value &&
+    !validPriceConditions().length
+  ) {
     await listProducts(limit, offset, productGateway)
     offset += limit
     if (productsVM.value.hasMore) {
@@ -150,6 +177,31 @@ const sort = ref<ProductsSort | undefined>(productsVM.value.currentSearch?.sort)
 const minimumQueryLength = 3
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
+const emptyPriceCondition = (): PriceConditionRow => ({
+  operator: 'lte',
+  amount: undefined
+})
+const restorePriceConditions = (): Array<PriceConditionRow> => {
+  const persisted = productsVM.value.currentSearch?.priceTtcConditions
+  if (!persisted?.length) return [emptyPriceCondition()]
+  return persisted.map((condition) => ({
+    operator: condition.operator,
+    amount: condition.value / 100
+  }))
+}
+const priceTtcConditions = ref<Array<PriceConditionRow>>(
+  restorePriceConditions()
+)
+const isValidPriceRow = (condition: PriceConditionRow) =>
+  condition.amount != null && condition.amount > 0
+const validPriceConditions = () =>
+  priceTtcConditions.value.filter(isValidPriceRow)
+const toSearchConditions = (rows: Array<PriceConditionRow>) =>
+  rows.filter(isValidPriceRow).map((condition) => ({
+    operator: condition.operator,
+    value: Math.round((condition.amount as number) * 100)
+  }))
+
 const buildFilters = (partial: {
   query?: string
   status?: ProductStatus
@@ -157,9 +209,13 @@ const buildFilters = (partial: {
   size?: number
   from?: number
 }) => {
+  const priceTtcConditionsFilter = toSearchConditions(priceTtcConditions.value)
   return {
     query: search.value,
     status: productStatus.value,
+    priceTtcConditions: priceTtcConditionsFilter.length
+      ? priceTtcConditionsFilter
+      : undefined,
     size: limit,
     sort: sort.value,
     ...partial
@@ -219,6 +275,38 @@ const clearProductStatus = () => {
     buildFilters({ status: undefined, from: 0 }),
     useSearchGateway()
   )
+}
+
+const searchWithCurrentFilters = () => {
+  searchOffset = 0
+  searchProducts(
+    String(routeName),
+    buildFilters({ from: 0 }),
+    useSearchGateway()
+  )
+}
+
+const priceConditionsChanged = (conditions: Array<PriceConditionRow>) => {
+  const before = JSON.stringify(toSearchConditions(priceTtcConditions.value))
+  priceTtcConditions.value = conditions
+  if (JSON.stringify(toSearchConditions(conditions)) === before) return
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(searchWithCurrentFilters, 300)
+}
+
+const removeFilter = (filter: ActiveFilterVM) => {
+  if (filter.key === 'priceTtc' && filter.index !== undefined) {
+    const target = validPriceConditions()[filter.index]
+    priceTtcConditions.value = priceTtcConditions.value.filter(
+      (condition) => condition !== target
+    )
+  }
+  searchWithCurrentFilters()
+}
+
+const clearAllFilters = () => {
+  priceTtcConditions.value = [emptyPriceCondition()]
+  searchWithCurrentFilters()
 }
 
 const productSelected = (uuid: string) => {

--- a/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
+++ b/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
@@ -1,3 +1,4 @@
+import { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 import { DeliveryStatus } from '@core/entities/delivery'
 import {
   getDeliveryStatus,
@@ -30,21 +31,6 @@ export interface GetOrdersItemVM {
   total: string
   paymentStatus: PaymentStatus
   deliveryStatus: DeliveryStatus
-}
-
-export type ActiveFilterKey =
-  | 'query'
-  | 'startDate'
-  | 'endDate'
-  | 'orderStatus'
-  | 'deliveryStatus'
-  | 'paymentStatus'
-  | 'totalTtc'
-
-export interface ActiveFilterVM {
-  key: ActiveFilterKey
-  index?: number
-  label: string
 }
 
 export interface GetOrdersVM {

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
@@ -307,6 +307,79 @@ describe('Get products VM', () => {
           expectVMToMatch(expectedVM)
         })
       })
+      describe('Active filters', () => {
+        it('should expose no active filter without a price condition', () => {
+          searchStore.setFilter(key, { query: 'dol' })
+          expectedVM = {
+            currentSearch: { query: 'dol' },
+            activeFilters: []
+          }
+          expectVMToMatch(expectedVM)
+        })
+        it('should expose a chip for a lower-or-equal price condition', () => {
+          searchStore.setFilter(key, {
+            priceTtcConditions: [{ operator: 'lte', value: 999 }]
+          })
+          expectedVM = {
+            currentSearch: {
+              priceTtcConditions: [{ operator: 'lte', value: 999 }]
+            },
+            activeFilters: [
+              { key: 'priceTtc', index: 0, label: 'Prix TTC ≤ 9,99 €' }
+            ]
+          }
+          expectVMToMatch(expectedVM)
+        })
+        it('should expose a chip for an equal price condition', () => {
+          searchStore.setFilter(key, {
+            priceTtcConditions: [{ operator: 'eq', value: 1550 }]
+          })
+          expectedVM = {
+            currentSearch: {
+              priceTtcConditions: [{ operator: 'eq', value: 1550 }]
+            },
+            activeFilters: [
+              { key: 'priceTtc', index: 0, label: 'Prix TTC = 15,50 €' }
+            ]
+          }
+          expectVMToMatch(expectedVM)
+        })
+        it('should expose a chip for a greater-or-equal price condition', () => {
+          searchStore.setFilter(key, {
+            priceTtcConditions: [{ operator: 'gte', value: 500 }]
+          })
+          expectedVM = {
+            currentSearch: {
+              priceTtcConditions: [{ operator: 'gte', value: 500 }]
+            },
+            activeFilters: [
+              { key: 'priceTtc', index: 0, label: 'Prix TTC ≥ 5,00 €' }
+            ]
+          }
+          expectVMToMatch(expectedVM)
+        })
+        it('should expose one chip per condition with its index', () => {
+          searchStore.setFilter(key, {
+            priceTtcConditions: [
+              { operator: 'gte', value: 500 },
+              { operator: 'lte', value: 999 }
+            ]
+          })
+          expectedVM = {
+            currentSearch: {
+              priceTtcConditions: [
+                { operator: 'gte', value: 500 },
+                { operator: 'lte', value: 999 }
+              ]
+            },
+            activeFilters: [
+              { key: 'priceTtc', index: 0, label: 'Prix TTC ≥ 5,00 €' },
+              { key: 'priceTtc', index: 1, label: 'Prix TTC ≤ 9,99 €' }
+            ]
+          }
+          expectVMToMatch(expectedVM)
+        })
+      })
       describe('Search performed but no results found', () => {
         beforeEach(() => {
           productStore.items = [dolodentListItem, ultraLevureListItem]
@@ -396,7 +469,8 @@ describe('Get products VM', () => {
       currentSearch: undefined,
       sort: undefined,
       searchError: undefined,
-      isLoading: false
+      isLoading: false,
+      activeFilters: []
     }
     expect(getProductsVM(key)).toMatchObject({ ...emptyVM, ...expectedVM })
   }

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
@@ -1,4 +1,5 @@
 import { Header } from '@adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM'
+import { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 import { ProductStatus } from '@core/entities/product'
 import { UUID } from '@core/types/types'
 import { ProductListItem } from '@core/usecases/product/product-listing/productListItem'
@@ -6,6 +7,7 @@ import {
   ProductsSort,
   SearchProductsFilters
 } from '@core/usecases/product/product-searching/searchProducts'
+import { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 import { useProductStore } from '@store/productStore'
 import { useSearchStore } from '@store/searchStore'
 import { priceFormatter } from '@utils/formatters'
@@ -33,6 +35,29 @@ export interface GetProductsVM {
   sort: ProductsSort | undefined
   searchError: string | undefined
   isLoading: boolean
+  activeFilters: Array<ActiveFilterVM>
+}
+
+const priceTtcOperatorSymbols: Record<PriceFilterOperator, string> = {
+  lte: '≤',
+  eq: '=',
+  gte: '≥'
+}
+
+const buildActiveFilters = (
+  filter: SearchProductsFilters | undefined
+): Array<ActiveFilterVM> => {
+  if (!filter) return []
+  const formatter = priceFormatter('fr-FR', 'EUR')
+  const activeFilters: Array<ActiveFilterVM> = []
+  filter.priceTtcConditions?.forEach((condition, index) => {
+    activeFilters.push({
+      key: 'priceTtc',
+      index,
+      label: `Prix TTC ${priceTtcOperatorSymbols[condition.operator]} ${formatter.format(condition.value / 100)}`
+    })
+  })
+  return activeFilters
 }
 
 export const getProductsVM = (key: string): GetProductsVM => {
@@ -118,6 +143,7 @@ export const getProductsVM = (key: string): GetProductsVM => {
       : undefined,
     hasMore: productStore.hasMore.valueOf(),
     hasMoreSearch,
-    isLoading
+    isLoading,
+    activeFilters: buildActiveFilters(searchFilter)
   }
 }

--- a/src/adapters/primary/view-models/shared/filters.ts
+++ b/src/adapters/primary/view-models/shared/filters.ts
@@ -1,0 +1,5 @@
+export interface ActiveFilterVM {
+  key: string
+  index?: number
+  label: string
+}

--- a/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
@@ -18,7 +18,10 @@ import {
   SearchOrdersDTO,
   TotalTtcCondition
 } from '@core/usecases/order/orders-searching/searchOrders'
-import { SearchProductsFilters } from '@core/usecases/product/product-searching/searchProducts'
+import {
+  PriceTtcCondition,
+  SearchProductsFilters
+} from '@core/usecases/product/product-searching/searchProducts'
 import { useCustomerStore } from '@store/customerStore'
 import { useOrderStore } from '@store/orderStore'
 import { addTaxToPrice } from '@utils/price'
@@ -38,27 +41,14 @@ export class FakeSearchGateway implements SearchGateway {
   ): Promise<SearchProductsResult> {
     const products = this.items.filter((i) => isProduct(i))
     const filtered = products.filter((p) => {
-      if (filters.query) {
-        const query = filters.query
-        const isCategoryNameMatching = p.categories.some((c) =>
-          c.name.includesWithoutCase(query)
-        )
-        const isNameMatching = p.name.includesWithoutCase(query)
-        const isLaboratoryMatching = p.laboratory
-          ? p.laboratory.name.includesWithoutCase(query)
-          : false
-        const isCip13Matching = p.cip13.includes(query)
-        return (
-          isNameMatching ||
-          isLaboratoryMatching ||
-          isCategoryNameMatching ||
-          isCip13Matching
-        )
-      }
-      if (filters.status) {
-        return p.status === filters.status
-      }
-      return true
+      const queryMatch = filters.query
+        ? this.productQueryMatch(p, filters.query)
+        : true
+      const statusMatch = filters.status ? p.status === filters.status : true
+      const priceTtcMatch = filters.priceTtcConditions?.length
+        ? this.productPriceTtcMatch(p, filters.priceTtcConditions)
+        : true
+      return queryMatch && statusMatch && priceTtcMatch
     })
     const sorted = this.sortProducts(filtered, filters)
     const total = sorted.length
@@ -77,6 +67,38 @@ export class FakeSearchGateway implements SearchGateway {
         totalPages
       },
       hasMore
+    })
+  }
+
+  private productQueryMatch = (product: any, query: string): boolean => {
+    const isCategoryNameMatching = product.categories.some((c: any) =>
+      c.name.includesWithoutCase(query)
+    )
+    const isNameMatching = product.name.includesWithoutCase(query)
+    const isLaboratoryMatching = product.laboratory
+      ? product.laboratory.name.includesWithoutCase(query)
+      : false
+    const isCip13Matching = product.cip13.includes(query)
+    return (
+      isNameMatching ||
+      isLaboratoryMatching ||
+      isCategoryNameMatching ||
+      isCip13Matching
+    )
+  }
+
+  private productPriceTtcMatch = (
+    product: any,
+    conditions: Array<PriceTtcCondition>
+  ): boolean => {
+    const priceWithTax = addTaxToPrice(
+      product.priceWithoutTax,
+      product.percentTaxRate
+    )
+    return conditions.every(({ operator, value }) => {
+      if (operator === 'lte') return priceWithTax <= value
+      if (operator === 'gte') return priceWithTax >= value
+      return Math.abs(priceWithTax - value) < 1
     })
   }
 

--- a/src/core/usecases/product/product-searching/searchProducts.spec.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.spec.ts
@@ -1,10 +1,12 @@
 import { FakeSearchGateway } from '@adapters/secondary/search-gateways/FakeSearchGateway'
-import { ProductStatus } from '@core/entities/product'
+import { Product, ProductStatus } from '@core/entities/product'
 import {
+  PriceTtcCondition,
   SearchProductsFilters,
   searchProducts
 } from '@core/usecases/product/product-searching/searchProducts'
 import { useSearchStore } from '@store/searchStore'
+import { addTaxToPrice } from '@utils/price'
 import { baby, dents } from '@utils/testData/categories'
 import {
   calmosine,
@@ -15,6 +17,9 @@ import {
   ultraLevure
 } from '@utils/testData/products'
 import { createPinia, setActivePinia } from 'pinia'
+
+const ttc = (product: Product): number =>
+  addTaxToPrice(product.priceWithoutTax, product.percentTaxRate)
 
 describe('Search products', () => {
   let searchStore: any
@@ -320,6 +325,40 @@ describe('Search products', () => {
         })
       })
     })
+    describe('Price TTC conditions filter', () => {
+      beforeEach(() => {
+        searchGateway.feedWith(dolodent, chamomilla, calmosine)
+      })
+      it('should get the products with price lower than or equal', async () => {
+        givenPriceTtcConditionsAre({ operator: 'lte', value: ttc(chamomilla) })
+        await whenSearchForProducts()
+        expectSearchResultToEqual(dolodent, chamomilla)
+      })
+      it('should get the products with price greater than or equal', async () => {
+        givenPriceTtcConditionsAre({ operator: 'gte', value: ttc(chamomilla) })
+        await whenSearchForProducts()
+        expectSearchResultToEqual(chamomilla, calmosine)
+      })
+      it('should get the products with price equal', async () => {
+        givenPriceTtcConditionsAre({ operator: 'eq', value: ttc(calmosine) })
+        await whenSearchForProducts()
+        expectSearchResultToEqual(calmosine)
+      })
+      it('should combine conditions with AND to get a price range', async () => {
+        givenPriceTtcConditionsAre(
+          { operator: 'gte', value: ttc(dolodent) },
+          { operator: 'lte', value: ttc(chamomilla) }
+        )
+        await whenSearchForProducts()
+        expectSearchResultToEqual(dolodent, chamomilla)
+      })
+      it('should combine the price condition with the query filter', async () => {
+        givenQueryIs('mo')
+        givenPriceTtcConditionsAre({ operator: 'gte', value: ttc(calmosine) })
+        await whenSearchForProducts()
+        expectSearchResultToEqual(calmosine)
+      })
+    })
   })
 
   describe('Loading state', () => {
@@ -436,6 +475,12 @@ describe('Search products', () => {
 
   const givenStatusFilterIs = (status: ProductStatus) => {
     filters.status = status
+  }
+
+  const givenPriceTtcConditionsAre = (
+    ...conditions: Array<PriceTtcCondition>
+  ) => {
+    filters.priceTtcConditions = conditions
   }
 
   const givenMinimumQueryLength = (length: number) => {

--- a/src/core/usecases/product/product-searching/searchProducts.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.ts
@@ -1,5 +1,6 @@
 import { ProductStatus } from '@core/entities/product'
 import { SearchGateway } from '@core/gateways/searchGateway'
+import { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 import { useSearchStore } from '@store/searchStore'
 
 export interface ProductsSort {
@@ -7,10 +8,16 @@ export interface ProductsSort {
   direction: 'asc' | 'desc'
 }
 
+export interface PriceTtcCondition {
+  operator: PriceFilterOperator
+  value: number
+}
+
 export interface SearchProductsFilters {
   query?: string
   minimumQueryLength?: number
   status?: ProductStatus
+  priceTtcConditions?: Array<PriceTtcCondition>
   size?: number
   from?: number
   sort?: ProductsSort
@@ -32,7 +39,12 @@ export const searchProducts = async (
     searchStore.set(key, [])
     searchStore.setPagination(key, { total: 0, from: 0, hasMore: false })
     searchStore.endLoading(key)
-  } else if (!filters.query && !filters.status && !filters.sort) {
+  } else if (
+    !filters.query &&
+    !filters.status &&
+    !filters.sort &&
+    !filters.priceTtcConditions?.length
+  ) {
     searchStore.clear(key)
     searchStore.setError(key, undefined)
     searchStore.endLoading(key)

--- a/src/core/usecases/shared/priceFilter.ts
+++ b/src/core/usecases/shared/priceFilter.ts
@@ -1,0 +1,1 @@
+export type PriceFilterOperator = 'lte' | 'eq' | 'gte'


### PR DESCRIPTION
## Context
Implements #145 — a price (TTC) filter on the admin products table, consistent with the Total TTC filter shipped for orders (#144). Products already expose the pre-computed `priceWithTax` in Elasticsearch, so the front sends `priceTtcConditions` to the backend and filters on that field (no client-side TTC computation).

## Changes
- **Filter**: reuse the orders price components (`FtPriceConditions`/`FtPriceFilter`) on the products page — operators ≤/=/≥, "Ajouter une condition", and active-filter chips (`FtFilterChips`) with one-click removal + "Tout effacer". State lives in the Pinia search store, like search/status.
- **Usecase**: `priceTtcConditions` added to `SearchProductsFilters`; a price-only filter now triggers a search.
- **VM**: `getProductsVM` builds the active-filter chips (`Prix TTC ≤ 9,99 €`).
- **Fake gateway**: query/status/price predicates are now ANDed; price matches the computed `priceWithTax`.
- **Decoupling**: extract shared `PriceFilterOperator` (core) and a generic `ActiveFilterVM` (view-models/shared) so the shared filter components no longer import order-specific types.
- **UI polish**: consistent control sizes (`lg`) and balanced widths across search/status/price; neutralized the shared price-filter aria-labels (generic "prix", valid for both products and orders).

## Tests
- `searchProducts.spec.ts`: `lte`/`eq`/`gte`/range/combined-with-query.
- `getProductsVM.spec.ts`: chip generation (operator symbol, € formatting, index).
- Full suite green (2452 tests), `vue-tsc` + `biome` clean.
- Verified end-to-end with Playwright against the running stack (≤ and = filters, chip display, clear-all; orders filter panel unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)