### PR TITLE
feat(#153): surface real carrier error on label generation failure

### DIFF
--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -41,7 +41,8 @@
     "expandAll": "Voir tout",
     "collapseAll": "Cacher tout",
     "active": "Actif",
-    "inactive": "Inactif"
+    "inactive": "Inactif",
+    "sortBy": "Trier par {name}"
   },
   "categories": {
     "status": {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -96,7 +96,11 @@
     "supportTickets": "Tickets de support",
     "deliveries": {
       "generateLabel": "Générer l'étiquette",
-      "generateLabelError": "Échec de la génération de l'étiquette. Veuillez réessayer."
+      "generateLabelError": "Échec de la génération de l'étiquette.",
+      "printLabelError": "Échec de l'impression de l'étiquette.",
+      "downloadLabelError": "Échec du téléchargement de l'étiquette.",
+      "carrierGenericError": "Aucun détail fourni par le transporteur. Vérifiez l'adresse et le point relais, puis réessayez.",
+      "carrierRawError": "Le transporteur a refusé la demande : {reason}"
     },
     "timeline": {
       "title": "Historique",

--- a/src/adapters/primary/nuxt/components/molecules/FtDeliveryStatusSelect.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtDeliveryStatusSelect.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-div.flex.items-center.justify-center
-  USelectMenu.w-32(
+div.flex.items-center.gap-2
+  USelectMenu.flex-grow(
     v-model="model"
     :options="options"
   )

--- a/src/adapters/primary/nuxt/components/molecules/FtFilterChips.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtFilterChips.vue
@@ -1,0 +1,40 @@
+<template lang="pug">
+div.flex.flex-wrap.items-center.gap-2(v-if="filters.length")
+  UButton(
+    v-for="(filter, index) in filters"
+    :key="index"
+    color="gray"
+    variant="soft"
+    size="xs"
+    trailing-icon="i-heroicons-x-mark-20-solid"
+    :aria-label="`Retirer le filtre ${filter.label}`"
+    @click="remove(filter)"
+  ) {{ filter.label }}
+  UButton(
+    color="gray"
+    variant="link"
+    size="xs"
+    @click="clearAll"
+  ) Tout effacer
+</template>
+
+<script lang="ts" setup>
+import type { ActiveFilterVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
+
+defineProps<{
+  filters: Array<ActiveFilterVM>
+}>()
+
+const emit = defineEmits<{
+  (e: 'remove', filter: ActiveFilterVM): void
+  (e: 'clearAll'): void
+}>()
+
+const remove = (filter: ActiveFilterVM) => {
+  emit('remove', filter)
+}
+
+const clearAll = () => {
+  emit('clearAll')
+}
+</script>

--- a/src/adapters/primary/nuxt/components/molecules/FtFilterChips.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtFilterChips.vue
@@ -19,7 +19,7 @@ div.flex.flex-wrap.items-center.gap-2(v-if="filters.length")
 </template>
 
 <script lang="ts" setup>
-import type { ActiveFilterVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
+import type { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 
 defineProps<{
   filters: Array<ActiveFilterVM>

--- a/src/adapters/primary/nuxt/components/molecules/FtOrderStatusSelect.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtOrderStatusSelect.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-div.flex.items-center.justify-center
-  USelectMenu.w-44(
+div.flex.items-center.gap-2
+  USelectMenu.flex-grow(
     v-model="model"
     :options="options"
   )

--- a/src/adapters/primary/nuxt/components/molecules/FtPaymentStatusSelect.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPaymentStatusSelect.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-div.flex.items-center.justify-center
-  USelectMenu.w-44(
+div.flex.items-center.gap-2
+  USelectMenu.flex-grow(
     v-model="model"
     :options="options"
   )

--- a/src/adapters/primary/nuxt/components/molecules/FtPriceConditions.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPriceConditions.vue
@@ -1,0 +1,69 @@
+<template lang="pug">
+div.space-y-2
+  ft-price-filter(
+    v-for="(condition, index) in conditions"
+    :key="index"
+    :operator="condition.operator"
+    :amount="condition.amount"
+    @update:operator="(operator) => updateOperator(index, operator)"
+    @update:amount="(amount) => updateAmount(index, amount)"
+    @remove="() => remove(index)"
+  )
+  UButton(
+    icon="i-heroicons-plus-20-solid"
+    color="gray"
+    variant="link"
+    size="xs"
+    :padded="false"
+    @click="add"
+  ) Ajouter une condition
+</template>
+
+<script lang="ts" setup>
+import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
+
+interface PriceConditionRow {
+  operator: TotalTtcOperator
+  amount: number | undefined
+}
+
+const props = defineProps<{
+  conditions: Array<PriceConditionRow>
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:conditions', value: Array<PriceConditionRow>): void
+}>()
+
+const updateOperator = (index: number, operator: TotalTtcOperator) => {
+  emit(
+    'update:conditions',
+    props.conditions.map((condition: PriceConditionRow, i: number) =>
+      i === index ? { ...condition, operator } : condition
+    )
+  )
+}
+
+const updateAmount = (index: number, amount: number | undefined) => {
+  emit(
+    'update:conditions',
+    props.conditions.map((condition: PriceConditionRow, i: number) =>
+      i === index ? { ...condition, amount } : condition
+    )
+  )
+}
+
+const remove = (index: number) => {
+  emit(
+    'update:conditions',
+    props.conditions.filter((_: PriceConditionRow, i: number) => i !== index)
+  )
+}
+
+const add = () => {
+  emit('update:conditions', [
+    ...props.conditions,
+    { operator: 'lte', amount: undefined }
+  ])
+}
+</script>

--- a/src/adapters/primary/nuxt/components/molecules/FtPriceConditions.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPriceConditions.vue
@@ -20,10 +20,10 @@ div.space-y-2
 </template>
 
 <script lang="ts" setup>
-import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
+import type { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 
 interface PriceConditionRow {
-  operator: TotalTtcOperator
+  operator: PriceFilterOperator
   amount: number | undefined
 }
 
@@ -35,7 +35,7 @@ const emit = defineEmits<{
   (e: 'update:conditions', value: Array<PriceConditionRow>): void
 }>()
 
-const updateOperator = (index: number, operator: TotalTtcOperator) => {
+const updateOperator = (index: number, operator: PriceFilterOperator) => {
   emit(
     'update:conditions',
     props.conditions.map((condition: PriceConditionRow, i: number) =>

--- a/src/adapters/primary/nuxt/components/molecules/FtPriceFilter.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPriceFilter.vue
@@ -1,0 +1,63 @@
+<template lang="pug">
+div.flex.items-center.gap-2
+  USelect.w-20(
+    :model-value="operator"
+    :options="operatorOptions"
+    value-attribute="value"
+    option-attribute="label"
+    aria-label="Opérateur de comparaison du total TTC"
+    @update:model-value="operatorChanged"
+  )
+  ft-text-field.flex-grow(
+    :model-value="amount"
+    type="number"
+    min="0"
+    step="0.01"
+    placeholder="Montant en €"
+    aria-label="Montant du filtre Total TTC en euros"
+    @update:model-value="amountChanged"
+  )
+  UButton(
+    color="gray"
+    variant="link"
+    icon="i-heroicons-x-mark-20-solid"
+    :padded="false"
+    aria-label="Supprimer cette condition de prix"
+    @click.prevent="remove"
+  )
+</template>
+
+<script lang="ts" setup>
+import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
+
+defineProps<{
+  operator: TotalTtcOperator
+  amount: number | undefined
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:operator', value: TotalTtcOperator): void
+  (e: 'update:amount', value: number | undefined): void
+  (e: 'remove'): void
+}>()
+
+const operatorOptions = [
+  { value: 'lte', label: '≤' },
+  { value: 'eq', label: '=' },
+  { value: 'gte', label: '≥' }
+]
+
+const operatorChanged = (value: TotalTtcOperator) => {
+  emit('update:operator', value)
+}
+
+const amountChanged = (value: string) => {
+  const parsed = Number(value)
+  const isValid = value !== '' && value !== null && !isNaN(parsed) && parsed > 0
+  emit('update:amount', isValid ? parsed : undefined)
+}
+
+const remove = () => {
+  emit('remove')
+}
+</script>

--- a/src/adapters/primary/nuxt/components/molecules/FtPriceFilter.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtPriceFilter.vue
@@ -1,23 +1,24 @@
 <template lang="pug">
 div.flex.items-center.gap-2
-  USelect.w-20(
+  USelect.w-20.shrink-0(
     :model-value="operator"
     :options="operatorOptions"
     value-attribute="value"
     option-attribute="label"
-    aria-label="Opérateur de comparaison du total TTC"
+    size="lg"
+    aria-label="Opérateur de comparaison du prix"
     @update:model-value="operatorChanged"
   )
-  ft-text-field.flex-grow(
+  ft-text-field.min-w-0.flex-1(
     :model-value="amount"
     type="number"
     min="0"
     step="0.01"
     placeholder="Montant en €"
-    aria-label="Montant du filtre Total TTC en euros"
+    aria-label="Montant du filtre en euros"
     @update:model-value="amountChanged"
   )
-  UButton(
+  UButton.shrink-0(
     color="gray"
     variant="link"
     icon="i-heroicons-x-mark-20-solid"
@@ -28,15 +29,15 @@ div.flex.items-center.gap-2
 </template>
 
 <script lang="ts" setup>
-import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
+import type { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 
 defineProps<{
-  operator: TotalTtcOperator
+  operator: PriceFilterOperator
   amount: number | undefined
 }>()
 
 const emit = defineEmits<{
-  (e: 'update:operator', value: TotalTtcOperator): void
+  (e: 'update:operator', value: PriceFilterOperator): void
   (e: 'update:amount', value: number | undefined): void
   (e: 'remove'): void
 }>()
@@ -47,7 +48,7 @@ const operatorOptions = [
   { value: 'gte', label: '≥' }
 ]
 
-const operatorChanged = (value: TotalTtcOperator) => {
+const operatorChanged = (value: PriceFilterOperator) => {
   emit('update:operator', value)
 }
 

--- a/src/adapters/primary/nuxt/components/molecules/FtProductStatusSelect.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtProductStatusSelect.vue
@@ -1,8 +1,9 @@
 <template lang="pug">
-div.flex.items-center.justify-center
+div.flex.items-center.gap-1
   USelectMenu.w-44(
     v-model="model"
     :options="options"
+    size="lg"
   )
     template(#label)
       ft-product-status-badge(v-if="model !== undefined" :status="model")

--- a/src/adapters/primary/nuxt/components/molecules/FtTable.vue
+++ b/src/adapters/primary/nuxt/components/molecules/FtTable.vue
@@ -26,7 +26,21 @@
               :key="headerIndex"
               :class="[headerIndex === 0 ? 'pl-4 pr-3 sm:pl-6' : 'px-3 lg:table-cell', 'text-left text-sm font-semibold text-default py-3.5']"
               scope='col'
-            ) {{ header.name }}
+              :aria-sort="ariaSort(header)"
+            )
+              button.inline-flex.items-center.gap-1.rounded(
+                v-if="header.sortable"
+                type="button"
+                class="cursor-pointer transition-colors duration-200 hover:text-colored focus:outline-none focus-visible:ring-2 focus-visible:ring-colored"
+                :aria-label="$t('common.sortBy', { name: header.name })"
+                @click.stop="sortBy(header.value)"
+              )
+                span {{ header.name }}
+                UIcon.h-4.w-4(
+                  :name="sortIcon(header)"
+                  :class="isSorted(header) ? 'text-colored' : 'text-gray-400'"
+                )
+              template(v-else) {{ header.name }}
         tbody(v-if="isLoading && items.length === 0")
           tr(v-for="i in 5" :key="i")
             td(v-if="selectable" class="relative w-12 px-6 sm:w-16 sm:px-8")
@@ -92,6 +106,10 @@ const props = defineProps({
     default: () => {
       return false
     }
+  },
+  sort: {
+    type: Object as PropType<{ field: string; direction: 'asc' | 'desc' }>,
+    default: undefined
   }
 })
 
@@ -104,7 +122,27 @@ const emit = defineEmits<{
   (e: 'clicked', value: any): void
   (e: 'item-selected', value: any): void
   (e: 'select-all', value: Array<any>): void
+  (e: 'sort', value: string): void
 }>()
+
+const isSorted = (header: any) => props.sort?.field === header.value
+
+const ariaSort = (header: any) => {
+  if (!header.sortable) return undefined
+  if (!isSorted(header)) return 'none'
+  return props.sort?.direction === 'asc' ? 'ascending' : 'descending'
+}
+
+const sortIcon = (header: any) => {
+  if (!isSorted(header)) return 'i-heroicons-chevron-up-down-20-solid'
+  return props.sort?.direction === 'asc'
+    ? 'i-heroicons-chevron-up-20-solid'
+    : 'i-heroicons-chevron-down-20-solid'
+}
+
+const sortBy = (value: string) => {
+  emit('sort', value)
+}
 
 const indeterminate = computed(() => {
   return (

--- a/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
+++ b/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
@@ -130,7 +130,7 @@ ft-table(
 
 <script lang="ts" setup>
 import FtTable from '@adapters/primary/nuxt/components/molecules/FtTable.vue'
-import type { ActiveFilterVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
+import type { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 import { listOrders } from '@core/usecases/order/list-orders/listOrders'
 import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
 import { searchOrders } from '@core/usecases/order/orders-searching/searchOrders'

--- a/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
+++ b/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
@@ -88,7 +88,7 @@ ft-table(
           @clear="clearPaymentStatus"
         )
   template(#infinite)
-    InfiniteLoading(@infinite="load")
+    InfiniteLoading(:identifier="infiniteIdentifier" @infinite="load")
       template(#complete)
         div
 </template>
@@ -139,6 +139,7 @@ let offset = 0
 let searchOffset = 0
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 const debounceDelay = 300
+const infiniteIdentifier = ref(0)
 
 const orderStore = useOrderStore()
 const searchStore = useSearchStore()
@@ -215,7 +216,7 @@ const load = async ($state: InfiniteLoadingState) => {
   if (searchStore.isLoading(props.searchKey)) {
     return
   }
-  if (!searchStore.hasMoreSearch(props.searchKey)) {
+  if (searchOffset > 0 && !searchStore.hasMoreSearch(props.searchKey)) {
     $state.complete()
     return
   }
@@ -232,10 +233,19 @@ const load = async ($state: InfiniteLoadingState) => {
   }
 }
 
-const triggerSearch = () => {
+const triggerSearch = async () => {
   searchStore.clear(props.searchKey)
-  searchOffset = limit
-  searchOrders(props.searchKey, dto({ from: 0 }), useSearchGateway())
+  offset = 0
+  orderStore.items = []
+  orderStore.hasMore = true
+  if (isSearchMode()) {
+    searchOffset = limit
+    await searchOrders(props.searchKey, dto({ from: 0 }), useSearchGateway())
+  } else {
+    searchStore.setFilter(props.searchKey, undefined)
+    searchOffset = 0
+  }
+  infiniteIdentifier.value++
 }
 
 const searchChanged = (e: any) => {

--- a/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
+++ b/src/adapters/primary/nuxt/components/organisms/OrdersList.vue
@@ -17,76 +17,111 @@ ft-table(
   template(#paymentStatus="{ item }")
     ft-payment-status-badge(:status="item.paymentStatus")
   template(#search)
-    div.flex.items-center.justify-center.space-x-4
-      ft-text-field.flex-grow(
-        v-model="search"
-        placeholder="Rechercher par référence, client, email"
-        for="search"
-        type='text'
-        name='search'
-        @input="searchChanged"
-      ) Rechercher une commande
-      UFormGroup.pb-4(label="Date de début" name="startDate")
-        UPopover(:popper="{ placement: 'bottom-start' }")
-          UButton(
-            icon="i-heroicons-calendar-days-20-solid"
-            :label="startDate ? format(startDate, 'd MMMM yyy', { locale: fr }) : ''"
+    div.space-y-3
+      div.flex.flex-wrap.items-center.gap-4
+        ft-text-field.flex-grow(
+          v-model="search"
+          placeholder="Rechercher par référence, client, email"
+          for="search"
+          type='text'
+          name='search'
+          @input="searchChanged"
+        ) Rechercher une commande
+        UButton(
+          icon="i-heroicons-funnel"
+          :color="showFilters ? 'primary' : 'gray'"
+          :variant="showFilters ? 'solid' : 'outline'"
+          aria-label="Afficher les filtres"
+          @click="toggleFilters"
+        )
+          span Filtres
+          UBadge.ml-2(
+            v-if="activeFiltersCount"
+            :label="String(activeFiltersCount)"
+            color="white"
+            size="xs"
           )
-            template(#trailing)
-              UButton(
-                v-show="startDate"
-                color="white"
-                variant="link"
-                icon="i-heroicons-x-mark-20-solid"
-                :padded="false"
-                @click.prevent="clearStartDate"
-              )
-          template(#panel="{ close }")
-            ft-date-picker(
-              v-model="startDate"
-              @update:model-value="startDateChanged"
-              @close="close"
+      ft-filter-chips(
+        :filters="vm.activeFilters || []"
+        @remove="removeFilter"
+        @clear-all="clearAllFilters"
+      )
+      div.grid.grid-cols-1.gap-4.rounded-lg.border.border-gray-200.p-4(
+        v-show="showFilters"
+        class="md:grid-cols-3"
+      )
+        UFormGroup(label="Date de début" name="startDate")
+          UPopover(:popper="{ placement: 'bottom-start' }")
+            UButton.w-full(
+              icon="i-heroicons-calendar-days-20-solid"
+              color="gray"
+              variant="outline"
+              :label="startDate ? format(startDate, 'd MMMM yyy', { locale: fr }) : 'Choisir une date'"
             )
-      UFormGroup.pb-4(label="Date de fin" name="endDate")
-        UPopover(:popper="{ placement: 'bottom-start' }")
-          UButton(
-            icon="i-heroicons-calendar-days-20-solid"
-            :label="endDate ? format(endDate, 'd MMMM yyy', { locale: fr }) : ''"
+              template(#trailing)
+                UButton(
+                  v-show="startDate"
+                  color="gray"
+                  variant="link"
+                  icon="i-heroicons-x-mark-20-solid"
+                  :padded="false"
+                  aria-label="Effacer la date de début"
+                  @click.prevent="clearStartDate"
+                )
+            template(#panel="{ close }")
+              ft-date-picker(
+                v-model="startDate"
+                @update:model-value="startDateChanged"
+                @close="close"
+              )
+        UFormGroup(label="Date de fin" name="endDate")
+          UPopover(:popper="{ placement: 'bottom-start' }")
+            UButton.w-full(
+              icon="i-heroicons-calendar-days-20-solid"
+              color="gray"
+              variant="outline"
+              :label="endDate ? format(endDate, 'd MMMM yyy', { locale: fr }) : 'Choisir une date'"
+            )
+              template(#trailing)
+                UButton(
+                  v-show="endDate"
+                  color="gray"
+                  variant="link"
+                  icon="i-heroicons-x-mark-20-solid"
+                  :padded="false"
+                  aria-label="Effacer la date de fin"
+                  @click.prevent="clearEndDate"
+                )
+            template(#panel="{ close }")
+              ft-date-picker(
+                v-model="endDate"
+                :is-end-date="true"
+                @update:model-value="endDateChanged"
+                @close="close"
+              )
+        UFormGroup(label="Statut" name="orderStatus")
+          ft-order-status-select(
+            v-model="orderStatus"
+            @update:model-value="orderStatusChanged"
+            @clear="clearOrderStatus"
           )
-            template(#trailing)
-              UButton(
-                v-show="endDate"
-                color="white"
-                variant="link"
-                icon="i-heroicons-x-mark-20-solid"
-                :padded="false"
-                @click.prevent="clearEndDate"
-              )
-          template(#panel="{ close }")
-            ft-date-picker(
-              v-model="endDate"
-              :is-end-date="true"
-              @update:model-value="endDateChanged"
-              @close="close"
-            )
-      UFormGroup.pb-4(label="Statut" name="orderStatus")
-        ft-order-status-select(
-          v-model="orderStatus"
-          @update:model-value="orderStatusChanged"
-          @clear="clearOrderStatus"
-        )
-      UFormGroup.pb-4(label="Statut de livraison" name="deliveryStatus")
-        ft-delivery-status-select(
-          v-model="deliveryStatus"
-          @update:model-value="deliveryStatusChanged"
-          @clear="clearDeliveryStatus"
-        )
-      UFormGroup.pb-4(label="Statut de paiement" name="paymentStatus")
-        ft-payment-status-select(
-          v-model="paymentStatus"
-          @update:model-value="paymentStatusChanged"
-          @clear="clearPaymentStatus"
-        )
+        UFormGroup(label="Statut de livraison" name="deliveryStatus")
+          ft-delivery-status-select(
+            v-model="deliveryStatus"
+            @update:model-value="deliveryStatusChanged"
+            @clear="clearDeliveryStatus"
+          )
+        UFormGroup(label="Statut de paiement" name="paymentStatus")
+          ft-payment-status-select(
+            v-model="paymentStatus"
+            @update:model-value="paymentStatusChanged"
+            @clear="clearPaymentStatus"
+          )
+        UFormGroup(label="Total TTC" name="totalTtc")
+          ft-price-conditions(
+            :conditions="totalTtcConditions"
+            @update:conditions="priceConditionsChanged"
+          )
   template(#infinite)
     InfiniteLoading(:identifier="infiniteIdentifier" @infinite="load")
       template(#complete)
@@ -95,7 +130,9 @@ ft-table(
 
 <script lang="ts" setup>
 import FtTable from '@adapters/primary/nuxt/components/molecules/FtTable.vue'
+import type { ActiveFilterVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
 import { listOrders } from '@core/usecases/order/list-orders/listOrders'
+import type { TotalTtcOperator } from '@core/usecases/order/orders-searching/searchOrders'
 import { searchOrders } from '@core/usecases/order/orders-searching/searchOrders'
 import { useOrderStore } from '@store/orderStore'
 import { useSearchStore } from '@store/searchStore'
@@ -109,6 +146,11 @@ import 'v3-infinite-loading/lib/style.css'
 interface InfiniteLoadingState {
   loaded: () => void
   complete: () => void
+}
+
+interface PriceConditionRow {
+  operator: TotalTtcOperator
+  amount: number | undefined
 }
 
 definePageMeta({ layout: 'main' })
@@ -162,6 +204,28 @@ const deliveryStatus = ref(
 const paymentStatus = ref(
   props.vm.value?.currentSearch?.paymentStatus || undefined
 )
+const emptyPriceCondition = (): PriceConditionRow => ({
+  operator: 'lte',
+  amount: undefined
+})
+const totalTtcConditions = ref<Array<PriceConditionRow>>([
+  emptyPriceCondition()
+])
+const showFilters = ref(false)
+
+const activeFiltersCount = computed(() => props.vm?.activeFilters?.length ?? 0)
+const isValidPriceRow = (condition: PriceConditionRow) =>
+  condition.amount != null && condition.amount > 0
+const validPriceConditions = () =>
+  totalTtcConditions.value.filter(isValidPriceRow)
+const toSearchConditions = (rows: Array<PriceConditionRow>) =>
+  rows.filter(isValidPriceRow).map((condition) => ({
+    operator: condition.operator,
+    value: Math.round((condition.amount as number) * 100)
+  }))
+const toggleFilters = () => {
+  showFilters.value = !showFilters.value
+}
 
 watch(
   () => props.vm,
@@ -183,6 +247,7 @@ const isSearchMode = () => {
       orderStatus.value !== undefined ||
       deliveryStatus.value !== undefined ||
       paymentStatus.value !== undefined ||
+      validPriceConditions().length > 0 ||
       props.initialFilters?.customerUuid
   )
 }
@@ -196,6 +261,9 @@ const dto = (partial: Record<string, any>) => {
     orderStatus: orderStatus.value,
     deliveryStatus: deliveryStatus.value,
     paymentStatus: paymentStatus.value,
+    totalTtcConditions: toSearchConditions(totalTtcConditions.value).length
+      ? toSearchConditions(totalTtcConditions.value)
+      : undefined,
     size: limit,
     from: 0,
     ...partial
@@ -301,6 +369,41 @@ const paymentStatusChanged = (stringStatus: string) => {
 
 const clearPaymentStatus = () => {
   paymentStatus.value = undefined
+  triggerSearch()
+}
+
+const priceConditionsChanged = (conditions: Array<PriceConditionRow>) => {
+  const before = JSON.stringify(toSearchConditions(totalTtcConditions.value))
+  totalTtcConditions.value = conditions
+  if (JSON.stringify(toSearchConditions(conditions)) === before) return
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(triggerSearch, debounceDelay)
+}
+
+const removeFilter = (filter: ActiveFilterVM) => {
+  if (filter.key === 'query') search.value = undefined
+  if (filter.key === 'startDate') startDate.value = undefined
+  if (filter.key === 'endDate') endDate.value = undefined
+  if (filter.key === 'orderStatus') orderStatus.value = undefined
+  if (filter.key === 'deliveryStatus') deliveryStatus.value = undefined
+  if (filter.key === 'paymentStatus') paymentStatus.value = undefined
+  if (filter.key === 'totalTtc' && filter.index !== undefined) {
+    const target = validPriceConditions()[filter.index]
+    totalTtcConditions.value = totalTtcConditions.value.filter(
+      (condition) => condition !== target
+    )
+  }
+  triggerSearch()
+}
+
+const clearAllFilters = () => {
+  search.value = undefined
+  startDate.value = undefined
+  endDate.value = undefined
+  orderStatus.value = undefined
+  deliveryStatus.value = undefined
+  paymentStatus.value = undefined
+  totalTtcConditions.value = [emptyPriceCondition()]
   triggerSearch()
 }
 

--- a/src/adapters/primary/nuxt/pages/customers/get/[uuid].vue
+++ b/src/adapters/primary/nuxt/pages/customers/get/[uuid].vue
@@ -24,10 +24,8 @@ import { customerFormGetVM } from '@adapters/primary/view-models/customers/custo
 import { getOrdersVM } from '@adapters/primary/view-models/orders/get-orders/getOrdersVM'
 import { getCustomer } from '@core/usecases/customers/customer-get/getCustomer'
 import { listCustomers } from '@core/usecases/customers/customer-listing/listCustomer'
-import { searchOrders } from '@core/usecases/order/orders-searching/searchOrders'
 import { getCustomerTickets } from '@core/usecases/support/getCustomerTickets'
 import { useCustomerGateway } from '../../../../../../../gateways/customerGateway'
-import { useSearchGateway } from '../../../../../../../gateways/searchGateway'
 import { useTicketGateway } from '../../../../../../../gateways/ticketGateway'
 
 definePageMeta({ layout: 'main' })
@@ -39,8 +37,6 @@ const router = useRouter()
 const routeName = router.currentRoute.value.name as string
 
 onMounted(async () => {
-  const searchGateway = useSearchGateway()
-  await searchOrders(routeName, { customerUuid }, searchGateway)
   const customerGateway = useCustomerGateway()
   await listCustomers(100, 0, customerGateway)
   await getCustomer(customerUuid, customerGateway)

--- a/src/adapters/primary/nuxt/pages/orders/[uuid].vue
+++ b/src/adapters/primary/nuxt/pages/orders/[uuid].vue
@@ -46,35 +46,48 @@
   )
     template(#title) Livraison
     template(#actions="{ item }")
-      div.flex.flex-col.items-end.gap-1
-        div.flex.items-center.gap-4
-          ft-button.button-default.py-4.px-4(
-            v-if="item.canGenerateLabel"
-            variant="outline"
-            @click="generateLabel"
-          ) {{ $t('orders.deliveries.generateLabel') }}
-          nuxt-link(
-            v-if="item.followUrl"
-            :to="item.followUrl"
-            target="_blank"
-          )
-            ft-button.button-default.py-4.px-4(variant="outline" @click.stop) Suivre le colis
-          ft-button.button-default.py-4.px-4(
-            v-if="item.canMarkAsDelivered"
-            variant="outline"
-            @click="markAsDelivered(item)"
-          ) Marquer comme livré
-          ft-button.button-default.py-4.px-4(
-            v-if="item.followUrl"
-            variant="outline"
-            @click="printLabel(item)"
-          ) Etiquette
-          ft-button.button-default.py-4.px-4(
-            v-if="item.followUrl"
-            variant="outline"
-            @click="downloadLabel(item)"
-          ) Télécharger
-        div.text-red-600.text-sm(v-if="generateLabelError") {{ generateLabelError }}
+      div.flex.items-center.gap-4.justify-end
+        ft-button.button-default.py-4.px-4(
+          v-if="item.canGenerateLabel"
+          variant="outline"
+          @click="generateLabel(item)"
+        ) {{ $t('orders.deliveries.generateLabel') }}
+        nuxt-link(
+          v-if="item.followUrl"
+          :to="item.followUrl"
+          target="_blank"
+        )
+          ft-button.button-default.py-4.px-4(variant="outline" @click.stop) Suivre le colis
+        ft-button.button-default.py-4.px-4(
+          v-if="item.canMarkAsDelivered"
+          variant="outline"
+          @click="markAsDelivered(item)"
+        ) Marquer comme livré
+        ft-button.button-default.py-4.px-4(
+          v-if="item.followUrl"
+          variant="outline"
+          @click="printLabel(item)"
+        ) Etiquette
+        ft-button.button-default.py-4.px-4(
+          v-if="item.followUrl"
+          variant="outline"
+          @click="downloadLabel(item)"
+        ) Télécharger
+  div.mt-4.flex.flex-col.gap-2(v-if="activeLabelErrors.length > 0")
+    UAlert(
+      v-for="entry in activeLabelErrors"
+      :key="entry.uuid"
+      color="red"
+      variant="soft"
+      icon="i-heroicons-exclamation-triangle"
+      :title="entry.content.title"
+      :close-button="{ icon: 'i-heroicons-x-mark-20-solid', color: 'red', variant: 'link', padded: true }"
+      role="alert"
+      @close="dismissLabelError(entry.uuid)"
+    )
+      template(#description)
+        div.text-xs.font-medium.opacity-80 {{ entry.deliveryLabel }}
+        div.mt-1 {{ entry.content.description }}
   ft-order-timeline.mt-8(:entries="timelineVM.entries")
   h2.text-subtitle.mt-8 {{ $t('orders.supportTickets') }}
   order-tickets-list(:order-uuid="orderUuid")
@@ -82,9 +95,11 @@
 </template>
 
 <script lang="ts" setup>
+import { carrierErrorToFrench } from '@adapters/primary/nuxt/utils/carrierErrorMessage'
 import { getOrderVM } from '@adapters/primary/view-models/orders/get-order/getOrderVM'
 import { getOrderTimelineVM } from '@adapters/primary/view-models/orders/get-order-timeline/getOrderTimelineVM'
 import { getPreparationVM } from '@adapters/primary/view-models/preparations/get-preparation/getPreparationVM'
+import { CarrierLabelError } from '@core/errors/CarrierLabelError'
 import { downloadDeliveryLabel } from '@core/usecases/deliveries/delivery-label-download/downloadDeliveryLabel'
 import { printDeliveryLabel } from '@core/usecases/deliveries/delivery-label-printing/printDeliveryLabel'
 import { generatePickup } from '@core/usecases/deliveries/delivery-pickup-generation/generatePickup'
@@ -98,6 +113,13 @@ import { useDeliveryGateway } from '../../../../../../gateways/deliveryGateway'
 import { useOrderGateway } from '../../../../../../gateways/orderGateway'
 import { useTicketGateway } from '../../../../../../gateways/ticketGateway'
 
+type LabelErrorContent = { title: string; description: string }
+type LabelErrorEntry = {
+  uuid: string
+  deliveryLabel: string
+  content: LabelErrorContent
+}
+
 definePageMeta({ layout: 'main' })
 
 const route = useRoute()
@@ -105,7 +127,22 @@ const orderUuid = String(route.params.uuid)
 const router = useRouter()
 const deliveryStore = useDeliveryStore()
 const { t } = useI18n()
-const generateLabelError = ref<string | null>(null)
+const labelErrors = ref<Record<string, LabelErrorContent | null>>({})
+
+const buildLabelError = (
+  titleKey: string,
+  error: unknown
+): LabelErrorContent => {
+  const detail = error instanceof CarrierLabelError ? error.detail : null
+  return {
+    title: t(titleKey),
+    description: carrierErrorToFrench(detail, t)
+  }
+}
+
+const dismissLabelError = (uuid: string) => {
+  labelErrors.value[uuid] = null
+}
 
 onMounted(() => {
   getPreparation(orderUuid, useOrderGateway())
@@ -125,21 +162,47 @@ const timelineVM = computed(() => {
   return getOrderTimelineVM()
 })
 
-const printLabel = (delivery: { uuid: string }) => {
-  printDeliveryLabel(delivery.uuid, useDeliveryGateway())
+const activeLabelErrors = computed<Array<LabelErrorEntry>>(() => {
+  return orderVM.value.deliveries
+    .map((delivery): LabelErrorEntry | null => {
+      const content = labelErrors.value[delivery.uuid]
+      if (!content) return null
+      return {
+        uuid: delivery.uuid,
+        deliveryLabel: `${delivery.method} · ${delivery.client}`,
+        content
+      }
+    })
+    .filter((entry): entry is LabelErrorEntry => entry !== null)
+})
+
+const printLabel = async (delivery: { uuid: string }) => {
+  labelErrors.value[delivery.uuid] = null
+  try {
+    await printDeliveryLabel(delivery.uuid, useDeliveryGateway())
+  } catch (error) {
+    labelErrors.value[delivery.uuid] = buildLabelError(
+      'orders.deliveries.printLabelError',
+      error
+    )
+  }
 }
 
-const generateLabel = async () => {
-  generateLabelError.value = null
+const generateLabel = async (delivery: { uuid: string }) => {
+  labelErrors.value[delivery.uuid] = null
   try {
     await generatePickup(orderUuid, useDeliveryGateway())
     await getOrder(orderUuid, useOrderGateway(), useCustomerGateway())
-  } catch {
-    generateLabelError.value = t('orders.deliveries.generateLabelError')
+  } catch (error) {
+    labelErrors.value[delivery.uuid] = buildLabelError(
+      'orders.deliveries.generateLabelError',
+      error
+    )
   }
 }
 
 const downloadLabel = async (delivery: { uuid: string }) => {
+  labelErrors.value[delivery.uuid] = null
   const newWindow = window.open('about:blank', '_blank')
 
   if (!newWindow) {
@@ -165,8 +228,11 @@ const downloadLabel = async (delivery: { uuid: string }) => {
       newWindow.close()
     }
   } catch (error) {
-    console.error('Error downloading label: ', error)
     newWindow.close()
+    labelErrors.value[delivery.uuid] = buildLabelError(
+      'orders.deliveries.downloadLabelError',
+      error
+    )
   }
 }
 

--- a/src/adapters/primary/nuxt/pages/products/index.vue
+++ b/src/adapters/primary/nuxt/pages/products/index.vue
@@ -13,7 +13,7 @@
     @item-selected="productSelector.toggleSelect"
     @select-all="productSelector.toggleSelectAll"
     @clicked="productSelected"
-    @sort="stockSortChanged"
+    @sort="sortChanged"
   )
     template(#title) Produits
     template(#search)
@@ -58,6 +58,7 @@ import { getProductsVM } from '@adapters/primary/view-models/products/get-produc
 import type { ProductStatus } from '@core/entities/product'
 import { listCategories } from '@core/usecases/categories/list-categories/listCategories'
 import { listProducts } from '@core/usecases/product/product-listing/listProducts'
+import type { ProductsSort } from '@core/usecases/product/product-searching/searchProducts'
 import { searchProducts } from '@core/usecases/product/product-searching/searchProducts'
 import { useCategoryStore } from '@store/categoryStore'
 import { dents, diarrhee } from '@utils/testData/categories'
@@ -107,7 +108,7 @@ const productsVM = computed(() => {
 })
 
 const load = async ($state: InfiniteLoadingState) => {
-  if (!search.value && !productStatus.value && !stockSort.value) {
+  if (!search.value && !productStatus.value && !sort.value) {
     await listProducts(limit, offset, productGateway)
     offset += limit
     if (productsVM.value.hasMore) {
@@ -145,9 +146,7 @@ const load = async ($state: InfiniteLoadingState) => {
 
 const search = ref(productsVM.value.currentSearch?.query)
 const productStatus = ref(productsVM.value.currentSearch?.status)
-const stockSort = ref<'asc' | 'desc' | undefined>(
-  productsVM.value.currentSearch?.sort?.direction
-)
+const sort = ref<ProductsSort | undefined>(productsVM.value.currentSearch?.sort)
 const minimumQueryLength = 3
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -162,22 +161,22 @@ const buildFilters = (partial: {
     query: search.value,
     status: productStatus.value,
     size: limit,
-    sort: stockSort.value
-      ? { field: 'availableStock', direction: stockSort.value }
-      : undefined,
+    sort: sort.value,
     ...partial
   }
 }
 
-const nextStockSort = (current: 'asc' | 'desc' | undefined) => {
-  if (current === undefined) return 'asc'
-  if (current === 'asc') return 'desc'
+const nextSort = (
+  current: ProductsSort | undefined,
+  field: string
+): ProductsSort | undefined => {
+  if (!current || current.field !== field) return { field, direction: 'asc' }
+  if (current.direction === 'asc') return { field, direction: 'desc' }
   return undefined
 }
 
-const stockSortChanged = (field: string) => {
-  if (field !== 'availableStock') return
-  stockSort.value = nextStockSort(stockSort.value)
+const sortChanged = (field: string) => {
+  sort.value = nextSort(sort.value, field)
   searchOffset = 0
   searchProducts(
     String(routeName),

--- a/src/adapters/primary/nuxt/pages/products/index.vue
+++ b/src/adapters/primary/nuxt/pages/products/index.vue
@@ -17,23 +17,38 @@
   )
     template(#title) Produits
     template(#search)
-      .flex.items-center.justify-center.space-x-4
-        .flex-grow
-          ft-text-field(
-            v-model="search"
-            placeholder="Rechercher par nom, référence, catégorie, laboratoire"
-            for="search"
-            type='text'
-            name='search'
-            @input="searchChanged"
-          ) Rechercher un produit
-          p.warning.text-warning(v-if="productsVM.searchError") {{ productsVM.searchError }}
-        UFormGroup.pb-4(label="Statut" name="productStatus")
-          ft-product-status-select(
-            v-model="productStatus"
-            @update:model-value="productStatusChanged"
-            @clear="clearProductStatus"
+      div.space-y-3
+        div.flex.flex-wrap.items-start.gap-4
+          UFormGroup(
+            class="flex-1 min-w-[16rem] max-w-md"
+            label="Recherche"
+            name="search"
           )
+            ft-text-field(
+              v-model="search"
+              placeholder="Rechercher par nom, référence, catégorie, laboratoire"
+              for="search"
+              type='text'
+              name='search'
+              @input="searchChanged"
+            )
+            p.warning.text-warning(v-if="productsVM.searchError") {{ productsVM.searchError }}
+          UFormGroup.shrink-0(label="Statut" name="productStatus")
+            ft-product-status-select(
+              v-model="productStatus"
+              @update:model-value="productStatusChanged"
+              @clear="clearProductStatus"
+            )
+          UFormGroup.shrink-0(class="w-72" label="Prix TTC" name="priceTtc")
+            ft-price-conditions(
+              :conditions="priceTtcConditions"
+              @update:conditions="priceConditionsChanged"
+            )
+        ft-filter-chips(
+          :filters="productsVM.activeFilters || []"
+          @remove="removeFilter"
+          @clear-all="clearAllFilters"
+        )
     template(#name="{ item }")
       .font-medium.text-default {{ item.name }}
     template(#infinite)
@@ -55,11 +70,13 @@
 
 <script lang="ts" setup>
 import { getProductsVM } from '@adapters/primary/view-models/products/get-products/getProductsVM'
+import type { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 import type { ProductStatus } from '@core/entities/product'
 import { listCategories } from '@core/usecases/categories/list-categories/listCategories'
 import { listProducts } from '@core/usecases/product/product-listing/listProducts'
 import type { ProductsSort } from '@core/usecases/product/product-searching/searchProducts'
 import { searchProducts } from '@core/usecases/product/product-searching/searchProducts'
+import type { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 import { useCategoryStore } from '@store/categoryStore'
 import { dents, diarrhee } from '@utils/testData/categories'
 import InfiniteLoading from 'v3-infinite-loading'
@@ -73,6 +90,11 @@ import { useSelection } from '../../composables/useSelection'
 interface InfiniteLoadingState {
   loaded: () => void
   complete: () => void
+}
+
+interface PriceConditionRow {
+  operator: PriceFilterOperator
+  amount: number | undefined
 }
 
 definePageMeta({ layout: 'main' })
@@ -108,7 +130,12 @@ const productsVM = computed(() => {
 })
 
 const load = async ($state: InfiniteLoadingState) => {
-  if (!search.value && !productStatus.value && !sort.value) {
+  if (
+    !search.value &&
+    !productStatus.value &&
+    !sort.value &&
+    !validPriceConditions().length
+  ) {
     await listProducts(limit, offset, productGateway)
     offset += limit
     if (productsVM.value.hasMore) {
@@ -150,6 +177,31 @@ const sort = ref<ProductsSort | undefined>(productsVM.value.currentSearch?.sort)
 const minimumQueryLength = 3
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
+const emptyPriceCondition = (): PriceConditionRow => ({
+  operator: 'lte',
+  amount: undefined
+})
+const restorePriceConditions = (): Array<PriceConditionRow> => {
+  const persisted = productsVM.value.currentSearch?.priceTtcConditions
+  if (!persisted?.length) return [emptyPriceCondition()]
+  return persisted.map((condition) => ({
+    operator: condition.operator,
+    amount: condition.value / 100
+  }))
+}
+const priceTtcConditions = ref<Array<PriceConditionRow>>(
+  restorePriceConditions()
+)
+const isValidPriceRow = (condition: PriceConditionRow) =>
+  condition.amount != null && condition.amount > 0
+const validPriceConditions = () =>
+  priceTtcConditions.value.filter(isValidPriceRow)
+const toSearchConditions = (rows: Array<PriceConditionRow>) =>
+  rows.filter(isValidPriceRow).map((condition) => ({
+    operator: condition.operator,
+    value: Math.round((condition.amount as number) * 100)
+  }))
+
 const buildFilters = (partial: {
   query?: string
   status?: ProductStatus
@@ -157,9 +209,13 @@ const buildFilters = (partial: {
   size?: number
   from?: number
 }) => {
+  const priceTtcConditionsFilter = toSearchConditions(priceTtcConditions.value)
   return {
     query: search.value,
     status: productStatus.value,
+    priceTtcConditions: priceTtcConditionsFilter.length
+      ? priceTtcConditionsFilter
+      : undefined,
     size: limit,
     sort: sort.value,
     ...partial
@@ -219,6 +275,38 @@ const clearProductStatus = () => {
     buildFilters({ status: undefined, from: 0 }),
     useSearchGateway()
   )
+}
+
+const searchWithCurrentFilters = () => {
+  searchOffset = 0
+  searchProducts(
+    String(routeName),
+    buildFilters({ from: 0 }),
+    useSearchGateway()
+  )
+}
+
+const priceConditionsChanged = (conditions: Array<PriceConditionRow>) => {
+  const before = JSON.stringify(toSearchConditions(priceTtcConditions.value))
+  priceTtcConditions.value = conditions
+  if (JSON.stringify(toSearchConditions(conditions)) === before) return
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(searchWithCurrentFilters, 300)
+}
+
+const removeFilter = (filter: ActiveFilterVM) => {
+  if (filter.key === 'priceTtc' && filter.index !== undefined) {
+    const target = validPriceConditions()[filter.index]
+    priceTtcConditions.value = priceTtcConditions.value.filter(
+      (condition) => condition !== target
+    )
+  }
+  searchWithCurrentFilters()
+}
+
+const clearAllFilters = () => {
+  priceTtcConditions.value = [emptyPriceCondition()]
+  searchWithCurrentFilters()
 }
 
 const productSelected = (uuid: string) => {

--- a/src/adapters/primary/nuxt/pages/products/index.vue
+++ b/src/adapters/primary/nuxt/pages/products/index.vue
@@ -9,9 +9,11 @@
     :is-loading="productsVM.isLoading"
     :selectable="true"
     :selection="productSelector.get()"
+    :sort="productsVM.sort"
     @item-selected="productSelector.toggleSelect"
     @select-all="productSelector.toggleSelectAll"
     @clicked="productSelected"
+    @sort="stockSortChanged"
   )
     template(#title) Produits
     template(#search)
@@ -105,7 +107,7 @@ const productsVM = computed(() => {
 })
 
 const load = async ($state: InfiniteLoadingState) => {
-  if (!search.value && !productStatus.value) {
+  if (!search.value && !productStatus.value && !stockSort.value) {
     await listProducts(limit, offset, productGateway)
     offset += limit
     if (productsVM.value.hasMore) {
@@ -114,7 +116,7 @@ const load = async ($state: InfiniteLoadingState) => {
       $state.complete()
     }
   } else {
-    if (productsVM.value.isSearchLoading) {
+    if (productsVM.value.isLoading) {
       return
     }
     if (!productsVM.value.hasMoreSearch) {
@@ -143,6 +145,9 @@ const load = async ($state: InfiniteLoadingState) => {
 
 const search = ref(productsVM.value.currentSearch?.query)
 const productStatus = ref(productsVM.value.currentSearch?.status)
+const stockSort = ref<'asc' | 'desc' | undefined>(
+  productsVM.value.currentSearch?.sort?.direction
+)
 const minimumQueryLength = 3
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -157,8 +162,28 @@ const buildFilters = (partial: {
     query: search.value,
     status: productStatus.value,
     size: limit,
+    sort: stockSort.value
+      ? { field: 'availableStock', direction: stockSort.value }
+      : undefined,
     ...partial
   }
+}
+
+const nextStockSort = (current: 'asc' | 'desc' | undefined) => {
+  if (current === undefined) return 'asc'
+  if (current === 'asc') return 'desc'
+  return undefined
+}
+
+const stockSortChanged = (field: string) => {
+  if (field !== 'availableStock') return
+  stockSort.value = nextStockSort(stockSort.value)
+  searchOffset = 0
+  searchProducts(
+    String(routeName),
+    buildFilters({ from: 0 }),
+    useSearchGateway()
+  )
 }
 
 const searchChanged = (e: any) => {

--- a/src/adapters/primary/nuxt/utils/carrierErrorMessage.ts
+++ b/src/adapters/primary/nuxt/utils/carrierErrorMessage.ts
@@ -1,0 +1,18 @@
+import type { CarrierErrorDetail } from '@core/errors/CarrierLabelError'
+
+type Translate = (key: string, params?: Record<string, unknown>) => string
+
+const FR_BY_ERROR_ID: Record<string, (raw: string) => string> = {
+  ShopIsOnHoliday: (raw) => `Point relais en congés. ${raw}`,
+  UnknownZipCodeCity: () => 'Adresse invalide : code postal / ville inconnus.'
+}
+
+export const carrierErrorToFrench = (
+  detail: CarrierErrorDetail | null,
+  t: Translate
+): string => {
+  if (!detail) return t('orders.deliveries.carrierGenericError')
+  const mapper = detail.errorId ? FR_BY_ERROR_ID[detail.errorId] : null
+  if (mapper) return mapper(detail.rawMessage)
+  return t('orders.deliveries.carrierRawError', { reason: detail.rawMessage })
+}

--- a/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.spec.ts
+++ b/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.spec.ts
@@ -3,6 +3,7 @@ import { DeliveryStatus } from '@core/entities/delivery'
 import { Order, OrderLineStatus, PaymentStatus } from '@core/entities/order'
 import { useOrderStore } from '@store/orderStore'
 import { useSearchStore } from '@store/searchStore'
+import { priceFormatter, timestampToLocaleString } from '@utils/formatters'
 import {
   orderNotPayed1,
   orderPrepared1,
@@ -141,6 +142,7 @@ describe('Get orders VM', () => {
         searchStore.set(key, [orderToPrepare1, orderNotPayed1])
         const expectedVM: Partial<GetOrdersVM> = {
           currentSearch: { query: 'jean' },
+          activeFilters: [{ key: 'query', label: 'Recherche : "jean"' }],
           items: [
             {
               reference: orderToPrepare1.uuid,
@@ -185,10 +187,60 @@ describe('Get orders VM', () => {
             endDate: 9234567890,
             orderStatus: OrderLineStatus.Started,
             paymentStatus: PaymentStatus.Payed
-          }
+          },
+          activeFilters: [
+            { key: 'query', label: 'Recherche : "test"' },
+            {
+              key: 'startDate',
+              label: `Depuis le ${timestampToLocaleString(1234567890, 'fr-FR')}`
+            },
+            {
+              key: 'endDate',
+              label: `Jusqu'au ${timestampToLocaleString(9234567890, 'fr-FR')}`
+            },
+            { key: 'orderStatus', label: 'Statut : En préparation' },
+            { key: 'paymentStatus', label: 'Paiement : Payé' }
+          ]
         }
         expectVMToMatch(expectedVM)
       })
+    })
+  })
+
+  describe('Active filters chips', () => {
+    it('should expose a chip for each active filter and each total condition', () => {
+      const low = 1000
+      const high = 2000
+      searchStore.setFilter(key, {
+        query: 'jean',
+        orderStatus: OrderLineStatus.Prepared,
+        totalTtcConditions: [
+          { operator: 'gte', value: low },
+          { operator: 'lte', value: high }
+        ]
+      })
+      const formatter = priceFormatter('fr-FR', 'EUR')
+      expect(getOrdersVM(key).activeFilters).toStrictEqual([
+        { key: 'query', label: 'Recherche : "jean"' },
+        { key: 'orderStatus', label: 'Statut : Préparé' },
+        {
+          key: 'totalTtc',
+          index: 0,
+          label: `Total TTC ≥ ${formatter.format(low / 100)}`
+        },
+        {
+          key: 'totalTtc',
+          index: 1,
+          label: `Total TTC ≤ ${formatter.format(high / 100)}`
+        }
+      ])
+    })
+    it('should use the search results when only the total filter is active', () => {
+      givenExistingOrders(orderToPrepare1)
+      searchStore.setFilter(key, {
+        totalTtcConditions: [{ operator: 'gte', value: 1 }]
+      })
+      expect(getOrdersVM(key).items).toStrictEqual([])
     })
   })
 
@@ -255,7 +307,8 @@ describe('Get orders VM', () => {
       hasMore: false,
       hasMoreSearch: false,
       isSearchLoading: false,
-      currentSearch: undefined
+      currentSearch: undefined,
+      activeFilters: []
     }
     expect(getOrdersVM(key)).toMatchObject({ ...emptyVM, ...expectedVM })
   }

--- a/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
+++ b/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
@@ -1,3 +1,4 @@
+import { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 import { DeliveryStatus } from '@core/entities/delivery'
 import {
   getDeliveryStatus,
@@ -30,21 +31,6 @@ export interface GetOrdersItemVM {
   total: string
   paymentStatus: PaymentStatus
   deliveryStatus: DeliveryStatus
-}
-
-export type ActiveFilterKey =
-  | 'query'
-  | 'startDate'
-  | 'endDate'
-  | 'orderStatus'
-  | 'deliveryStatus'
-  | 'paymentStatus'
-  | 'totalTtc'
-
-export interface ActiveFilterVM {
-  key: ActiveFilterKey
-  index?: number
-  label: string
 }
 
 export interface GetOrdersVM {

--- a/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
+++ b/src/adapters/primary/view-models/orders/get-orders/getOrdersVM.ts
@@ -7,7 +7,10 @@ import {
   OrderLineStatus,
   PaymentStatus
 } from '@core/entities/order'
-import { SearchOrdersDTO } from '@core/usecases/order/orders-searching/searchOrders'
+import {
+  SearchOrdersDTO,
+  TotalTtcOperator
+} from '@core/usecases/order/orders-searching/searchOrders'
 import { useOrderStore } from '@store/orderStore'
 import { useSearchStore } from '@store/searchStore'
 import { priceFormatter, timestampToLocaleString } from '@utils/formatters'
@@ -29,6 +32,21 @@ export interface GetOrdersItemVM {
   deliveryStatus: DeliveryStatus
 }
 
+export type ActiveFilterKey =
+  | 'query'
+  | 'startDate'
+  | 'endDate'
+  | 'orderStatus'
+  | 'deliveryStatus'
+  | 'paymentStatus'
+  | 'totalTtc'
+
+export interface ActiveFilterVM {
+  key: ActiveFilterKey
+  index?: number
+  label: string
+}
+
 export interface GetOrdersVM {
   headers: Array<Header>
   items: Array<GetOrdersItemVM>
@@ -37,6 +55,7 @@ export interface GetOrdersVM {
   hasMoreSearch: boolean
   isSearchLoading: boolean
   currentSearch: SearchOrdersDTO | undefined
+  activeFilters: Array<ActiveFilterVM>
 }
 
 const headers: Array<Header> = [
@@ -112,8 +131,84 @@ const isAnyFilterActive = (filter: SearchOrdersDTO | undefined): boolean => {
       filter.orderStatus !== undefined ||
       filter.deliveryStatus !== undefined ||
       filter.paymentStatus !== undefined ||
-      filter.customerUuid
+      filter.customerUuid ||
+      filter.totalTtcConditions?.length
   )
+}
+
+const orderStatusChipLabels: Record<OrderLineStatus, string> = {
+  [OrderLineStatus.Created]: 'Crée',
+  [OrderLineStatus.Started]: 'En préparation',
+  [OrderLineStatus.Prepared]: 'Préparé',
+  [OrderLineStatus.Canceled]: 'Annulé'
+}
+
+const deliveryStatusChipLabels: Record<DeliveryStatus, string> = {
+  [DeliveryStatus.Created]: 'Crée',
+  [DeliveryStatus.Prepared]: 'Préparé',
+  [DeliveryStatus.Shipped]: 'Expédié',
+  [DeliveryStatus.Delivered]: 'Livré'
+}
+
+const paymentStatusChipLabels: Record<PaymentStatus, string> = {
+  [PaymentStatus.WaitingForPayment]: 'En attente de paiement',
+  [PaymentStatus.Payed]: 'Payé',
+  [PaymentStatus.Rejected]: 'Payment rejeté'
+}
+
+const totalTtcOperatorSymbols: Record<TotalTtcOperator, string> = {
+  lte: '≤',
+  eq: '=',
+  gte: '≥'
+}
+
+const buildActiveFilters = (
+  filter: SearchOrdersDTO | undefined
+): Array<ActiveFilterVM> => {
+  if (!filter) return []
+  const formatter = priceFormatter('fr-FR', 'EUR')
+  const activeFilters: Array<ActiveFilterVM> = []
+  if (filter.query) {
+    activeFilters.push({ key: 'query', label: `Recherche : "${filter.query}"` })
+  }
+  if (filter.startDate) {
+    activeFilters.push({
+      key: 'startDate',
+      label: `Depuis le ${timestampToLocaleString(filter.startDate, 'fr-FR')}`
+    })
+  }
+  if (filter.endDate) {
+    activeFilters.push({
+      key: 'endDate',
+      label: `Jusqu'au ${timestampToLocaleString(filter.endDate, 'fr-FR')}`
+    })
+  }
+  if (filter.orderStatus !== undefined) {
+    activeFilters.push({
+      key: 'orderStatus',
+      label: `Statut : ${orderStatusChipLabels[filter.orderStatus]}`
+    })
+  }
+  if (filter.deliveryStatus !== undefined) {
+    activeFilters.push({
+      key: 'deliveryStatus',
+      label: `Livraison : ${deliveryStatusChipLabels[filter.deliveryStatus]}`
+    })
+  }
+  if (filter.paymentStatus !== undefined) {
+    activeFilters.push({
+      key: 'paymentStatus',
+      label: `Paiement : ${paymentStatusChipLabels[filter.paymentStatus]}`
+    })
+  }
+  filter.totalTtcConditions?.forEach((condition, index) => {
+    activeFilters.push({
+      key: 'totalTtc',
+      index,
+      label: `Total TTC ${totalTtcOperatorSymbols[condition.operator]} ${formatter.format(condition.value / 100)}`
+    })
+  })
+  return activeFilters
 }
 
 export const getOrdersVM = (key: string): GetOrdersVM => {
@@ -130,6 +225,7 @@ export const getOrdersVM = (key: string): GetOrdersVM => {
     hasMore: orderStore.hasMore,
     hasMoreSearch: searchStore.hasMoreSearch(key),
     isSearchLoading: searchStore.isLoading(key),
-    currentSearch: searchFilter
+    currentSearch: searchFilter,
+    activeFilters: buildActiveFilters(searchFilter)
   }
 }

--- a/src/adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM.ts
+++ b/src/adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM.ts
@@ -27,6 +27,7 @@ export interface GetPreparationsItemVM {
 export interface Header {
   name: string
   value: string
+  sortable?: boolean
 }
 
 interface GetPreparationsGroupVM {

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
@@ -307,6 +307,79 @@ describe('Get products VM', () => {
           expectVMToMatch(expectedVM)
         })
       })
+      describe('Active filters', () => {
+        it('should expose no active filter without a price condition', () => {
+          searchStore.setFilter(key, { query: 'dol' })
+          expectedVM = {
+            currentSearch: { query: 'dol' },
+            activeFilters: []
+          }
+          expectVMToMatch(expectedVM)
+        })
+        it('should expose a chip for a lower-or-equal price condition', () => {
+          searchStore.setFilter(key, {
+            priceTtcConditions: [{ operator: 'lte', value: 999 }]
+          })
+          expectedVM = {
+            currentSearch: {
+              priceTtcConditions: [{ operator: 'lte', value: 999 }]
+            },
+            activeFilters: [
+              { key: 'priceTtc', index: 0, label: 'Prix TTC ≤ 9,99 €' }
+            ]
+          }
+          expectVMToMatch(expectedVM)
+        })
+        it('should expose a chip for an equal price condition', () => {
+          searchStore.setFilter(key, {
+            priceTtcConditions: [{ operator: 'eq', value: 1550 }]
+          })
+          expectedVM = {
+            currentSearch: {
+              priceTtcConditions: [{ operator: 'eq', value: 1550 }]
+            },
+            activeFilters: [
+              { key: 'priceTtc', index: 0, label: 'Prix TTC = 15,50 €' }
+            ]
+          }
+          expectVMToMatch(expectedVM)
+        })
+        it('should expose a chip for a greater-or-equal price condition', () => {
+          searchStore.setFilter(key, {
+            priceTtcConditions: [{ operator: 'gte', value: 500 }]
+          })
+          expectedVM = {
+            currentSearch: {
+              priceTtcConditions: [{ operator: 'gte', value: 500 }]
+            },
+            activeFilters: [
+              { key: 'priceTtc', index: 0, label: 'Prix TTC ≥ 5,00 €' }
+            ]
+          }
+          expectVMToMatch(expectedVM)
+        })
+        it('should expose one chip per condition with its index', () => {
+          searchStore.setFilter(key, {
+            priceTtcConditions: [
+              { operator: 'gte', value: 500 },
+              { operator: 'lte', value: 999 }
+            ]
+          })
+          expectedVM = {
+            currentSearch: {
+              priceTtcConditions: [
+                { operator: 'gte', value: 500 },
+                { operator: 'lte', value: 999 }
+              ]
+            },
+            activeFilters: [
+              { key: 'priceTtc', index: 0, label: 'Prix TTC ≥ 5,00 €' },
+              { key: 'priceTtc', index: 1, label: 'Prix TTC ≤ 9,99 €' }
+            ]
+          }
+          expectVMToMatch(expectedVM)
+        })
+      })
       describe('Search performed but no results found', () => {
         beforeEach(() => {
           productStore.items = [dolodentListItem, ultraLevureListItem]
@@ -396,7 +469,8 @@ describe('Get products VM', () => {
       currentSearch: undefined,
       sort: undefined,
       searchError: undefined,
-      isLoading: false
+      isLoading: false,
+      activeFilters: []
     }
     expect(getProductsVM(key)).toMatchObject({ ...emptyVM, ...expectedVM })
   }

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
@@ -48,11 +48,13 @@ describe('Get products VM', () => {
     },
     {
       name: 'Prix HT',
-      value: 'priceWithoutTax'
+      value: 'priceWithoutTax',
+      sortable: true
     },
     {
       name: 'Prix TTC',
-      value: 'priceWithTax'
+      value: 'priceWithTax',
+      sortable: true
     },
     {
       name: 'Stock',
@@ -285,6 +287,22 @@ describe('Get products VM', () => {
               sort: { field: 'availableStock', direction: 'asc' }
             },
             sort: { field: 'availableStock', direction: 'asc' }
+          }
+          expectVMToMatch(expectedVM)
+        })
+      })
+      describe('There is a price sort', () => {
+        beforeEach(() => {
+          searchStore.setFilter(key, {
+            sort: { field: 'priceWithTax', direction: 'desc' }
+          })
+        })
+        it('should expose the current sort', () => {
+          expectedVM = {
+            currentSearch: {
+              sort: { field: 'priceWithTax', direction: 'desc' }
+            },
+            sort: { field: 'priceWithTax', direction: 'desc' }
           }
           expectVMToMatch(expectedVM)
         })

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.spec.ts
@@ -56,7 +56,8 @@ describe('Get products VM', () => {
     },
     {
       name: 'Stock',
-      value: 'availableStock'
+      value: 'availableStock',
+      sortable: true
     },
     {
       name: 'Statut',
@@ -272,6 +273,22 @@ describe('Get products VM', () => {
           expectVMToMatch(expectedVM)
         })
       })
+      describe('There is a sort', () => {
+        beforeEach(() => {
+          searchStore.setFilter(key, {
+            sort: { field: 'availableStock', direction: 'asc' }
+          })
+        })
+        it('should expose the current sort', () => {
+          expectedVM = {
+            currentSearch: {
+              sort: { field: 'availableStock', direction: 'asc' }
+            },
+            sort: { field: 'availableStock', direction: 'asc' }
+          }
+          expectVMToMatch(expectedVM)
+        })
+      })
       describe('Search performed but no results found', () => {
         beforeEach(() => {
           productStore.items = [dolodentListItem, ultraLevureListItem]
@@ -343,10 +360,10 @@ describe('Get products VM', () => {
       }
       expectVMToMatch(expectedVM)
     })
-    it('should expose isSearchLoading from search store', () => {
+    it('should be loading while a search is in progress', () => {
       searchStore.startLoading(key)
       expectedVM = {
-        isSearchLoading: true
+        isLoading: true
       }
       expectVMToMatch(expectedVM)
     })
@@ -359,9 +376,9 @@ describe('Get products VM', () => {
       hasMore: false,
       hasMoreSearch: false,
       currentSearch: undefined,
+      sort: undefined,
       searchError: undefined,
-      isLoading: false,
-      isSearchLoading: false
+      isLoading: false
     }
     expect(getProductsVM(key)).toMatchObject({ ...emptyVM, ...expectedVM })
   }

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
@@ -1,4 +1,5 @@
 import { Header } from '@adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM'
+import { ActiveFilterVM } from '@adapters/primary/view-models/shared/filters'
 import { ProductStatus } from '@core/entities/product'
 import { UUID } from '@core/types/types'
 import { ProductListItem } from '@core/usecases/product/product-listing/productListItem'
@@ -6,6 +7,7 @@ import {
   ProductsSort,
   SearchProductsFilters
 } from '@core/usecases/product/product-searching/searchProducts'
+import { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 import { useProductStore } from '@store/productStore'
 import { useSearchStore } from '@store/searchStore'
 import { priceFormatter } from '@utils/formatters'
@@ -33,6 +35,29 @@ export interface GetProductsVM {
   sort: ProductsSort | undefined
   searchError: string | undefined
   isLoading: boolean
+  activeFilters: Array<ActiveFilterVM>
+}
+
+const priceTtcOperatorSymbols: Record<PriceFilterOperator, string> = {
+  lte: '≤',
+  eq: '=',
+  gte: '≥'
+}
+
+const buildActiveFilters = (
+  filter: SearchProductsFilters | undefined
+): Array<ActiveFilterVM> => {
+  if (!filter) return []
+  const formatter = priceFormatter('fr-FR', 'EUR')
+  const activeFilters: Array<ActiveFilterVM> = []
+  filter.priceTtcConditions?.forEach((condition, index) => {
+    activeFilters.push({
+      key: 'priceTtc',
+      index,
+      label: `Prix TTC ${priceTtcOperatorSymbols[condition.operator]} ${formatter.format(condition.value / 100)}`
+    })
+  })
+  return activeFilters
 }
 
 export const getProductsVM = (key: string): GetProductsVM => {
@@ -118,6 +143,7 @@ export const getProductsVM = (key: string): GetProductsVM => {
       : undefined,
     hasMore: productStore.hasMore.valueOf(),
     hasMoreSearch,
-    isLoading
+    isLoading,
+    activeFilters: buildActiveFilters(searchFilter)
   }
 }

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
@@ -2,7 +2,10 @@ import { Header } from '@adapters/primary/view-models/preparations/get-orders-to
 import { ProductStatus } from '@core/entities/product'
 import { UUID } from '@core/types/types'
 import { ProductListItem } from '@core/usecases/product/product-listing/productListItem'
-import { SearchProductsFilters } from '@core/usecases/product/product-searching/searchProducts'
+import {
+  ProductsSort,
+  SearchProductsFilters
+} from '@core/usecases/product/product-searching/searchProducts'
 import { useProductStore } from '@store/productStore'
 import { useSearchStore } from '@store/searchStore'
 import { priceFormatter } from '@utils/formatters'
@@ -27,21 +30,20 @@ export interface GetProductsVM {
   hasMore: boolean
   hasMoreSearch: boolean
   currentSearch: SearchProductsFilters | undefined
+  sort: ProductsSort | undefined
   searchError: string | undefined
   isLoading: boolean
-  isSearchLoading: boolean
 }
 
 export const getProductsVM = (key: string): GetProductsVM => {
   const productStore = useProductStore()
-  const isLoading = productStore.isLoading
   const searchStore = useSearchStore()
   const allProducts = productStore.items
   const searchResult = searchStore.get(key)
   const searchFilter = searchStore.getFilter(key)
   const searchError = searchStore.getError(key)
   const hasMoreSearch = searchStore.hasMoreSearch(key)
-  const isSearchLoading = searchStore.isLoading(key)
+  const isLoading = productStore.isLoading || searchStore.isLoading(key)
   const products = searchResult !== undefined ? searchResult : allProducts
   const formatter = priceFormatter('fr-FR', 'EUR')
   const headers: Array<Header> = [
@@ -75,7 +77,8 @@ export const getProductsVM = (key: string): GetProductsVM => {
     },
     {
       name: 'Stock',
-      value: 'availableStock'
+      value: 'availableStock',
+      sortable: true
     },
     {
       name: 'Statut',
@@ -107,12 +110,12 @@ export const getProductsVM = (key: string): GetProductsVM => {
       }
     }),
     currentSearch: searchFilter,
+    sort: searchFilter?.sort,
     searchError: searchError
       ? 'Veuillez saisir au moins 3 caractères pour lancer la recherche.'
       : undefined,
     hasMore: productStore.hasMore.valueOf(),
     hasMoreSearch,
-    isLoading,
-    isSearchLoading
+    isLoading
   }
 }

--- a/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
+++ b/src/adapters/primary/view-models/products/get-products/getProductsVM.ts
@@ -69,11 +69,13 @@ export const getProductsVM = (key: string): GetProductsVM => {
     },
     {
       name: 'Prix HT',
-      value: 'priceWithoutTax'
+      value: 'priceWithoutTax',
+      sortable: true
     },
     {
       name: 'Prix TTC',
-      value: 'priceWithTax'
+      value: 'priceWithTax',
+      sortable: true
     },
     {
       name: 'Stock',

--- a/src/adapters/primary/view-models/shared/filters.ts
+++ b/src/adapters/primary/view-models/shared/filters.ts
@@ -1,0 +1,5 @@
+export interface ActiveFilterVM {
+  key: string
+  index?: number
+  label: string
+}

--- a/src/adapters/secondary/delivery-gateways/inMemoryDeliveryGateway.ts
+++ b/src/adapters/secondary/delivery-gateways/inMemoryDeliveryGateway.ts
@@ -8,6 +8,8 @@ export class InMemoryDeliveryGateway implements DeliveryGateway {
   private downloaded: Array<UUID> = []
   private generatedPickups: Array<UUID> = []
   private generatePickupError: Error | null = null
+  private printLabelError: Error | null = null
+  private downloadLabelError: Error | null = null
 
   list(): Promise<Array<Delivery>> {
     return Promise.resolve(JSON.parse(JSON.stringify(this.deliveries)))
@@ -26,11 +28,17 @@ export class InMemoryDeliveryGateway implements DeliveryGateway {
   }
 
   printLabel(uuid: UUID): Promise<void> {
+    if (this.printLabelError) {
+      return Promise.reject(this.printLabelError)
+    }
     this.printed.push(uuid)
     return Promise.resolve()
   }
 
   downloadLabel(uuid: UUID): Promise<Blob> {
+    if (this.downloadLabelError) {
+      return Promise.reject(this.downloadLabelError)
+    }
     this.downloaded.push(uuid)
     return Promise.resolve(new Blob([uuid], { type: 'application/pdf' }))
   }
@@ -65,6 +73,14 @@ export class InMemoryDeliveryGateway implements DeliveryGateway {
 
   feedGeneratePickupError(error: Error) {
     this.generatePickupError = error
+  }
+
+  feedPrintLabelError(error: Error) {
+    this.printLabelError = error
+  }
+
+  feedDownloadLabelError(error: Error) {
+    this.downloadLabelError = error
   }
 
   feedWith(...deliveries: Array<Delivery>) {

--- a/src/adapters/secondary/delivery-gateways/realDeliveryGateway.ts
+++ b/src/adapters/secondary/delivery-gateways/realDeliveryGateway.ts
@@ -1,8 +1,13 @@
 import { axiosWithBearer } from '@adapters/primary/nuxt/utils/axios'
 import { RealGateway } from '@adapters/secondary/order-gateways/RealOrderGateway'
 import { Delivery, DeliveryStatus } from '@core/entities/delivery'
+import {
+  CarrierErrorDetail,
+  CarrierLabelError
+} from '@core/errors/CarrierLabelError'
 import { DeliveryGateway } from '@core/gateways/deliveryGateway'
 import { UUID } from '@core/types/types'
+import axios, { AxiosError } from 'axios'
 
 export class RealDeliveryGateway
   extends RealGateway
@@ -46,21 +51,73 @@ export class RealDeliveryGateway
   }
 
   async printLabel(uuid: UUID): Promise<void> {
-    await axiosWithBearer.post(`${this.baseUrl}/deliveries/${uuid}/print-label`)
+    try {
+      await axiosWithBearer.post(
+        `${this.baseUrl}/deliveries/${uuid}/print-label`
+      )
+    } catch (e) {
+      throw await this.toCarrierError(e)
+    }
   }
 
   async downloadLabel(uuid: UUID): Promise<Blob> {
-    const res = await axiosWithBearer.get(
-      `${this.baseUrl}/deliveries/${uuid}/download-label`,
-      {
-        responseType: 'blob'
-      }
-    )
-    return new Blob([res.data], { type: 'application/pdf' })
+    try {
+      const res = await axiosWithBearer.get(
+        `${this.baseUrl}/deliveries/${uuid}/download-label`,
+        {
+          responseType: 'blob'
+        }
+      )
+      return new Blob([res.data], { type: 'application/pdf' })
+    } catch (e) {
+      throw await this.toCarrierError(e)
+    }
   }
 
   async generatePickup(orderUuid: UUID): Promise<void> {
-    await axiosWithBearer.post(`${this.baseUrl}/pickup`, { orderUuid })
+    try {
+      await axiosWithBearer.post(`${this.baseUrl}/pickup`, { orderUuid })
+    } catch (e) {
+      throw await this.toCarrierError(e)
+    }
+  }
+
+  private async toCarrierError(error: unknown): Promise<unknown> {
+    if (axios.isAxiosError(error) && error.response?.status === 500) {
+      const detail = await this.readCarrierErrorDetail(error)
+      if (detail !== undefined) {
+        return new CarrierLabelError(detail)
+      }
+    }
+    return error
+  }
+
+  private async readCarrierErrorDetail(
+    error: AxiosError
+  ): Promise<CarrierErrorDetail | null | undefined> {
+    const data = error.response?.data
+    if (data instanceof Blob) {
+      const text = await data.text()
+      try {
+        const parsed = JSON.parse(text) as { carrierError?: unknown }
+        return this.extractCarrierError(parsed)
+      } catch {
+        return undefined
+      }
+    }
+    if (typeof data === 'object' && data !== null) {
+      return this.extractCarrierError(data as Record<string, unknown>)
+    }
+    return undefined
+  }
+
+  private extractCarrierError(
+    body: Record<string, unknown> | { carrierError?: unknown }
+  ): CarrierErrorDetail | null | undefined {
+    if (!('carrierError' in body)) return undefined
+    const carrierError = (body as { carrierError: unknown }).carrierError
+    if (carrierError === null) return null
+    return carrierError as CarrierErrorDetail
   }
 
   private convertToDelivery(delivery: any) {

--- a/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
@@ -21,6 +21,7 @@ import {
 import { SearchProductsFilters } from '@core/usecases/product/product-searching/searchProducts'
 import { useCustomerStore } from '@store/customerStore'
 import { useOrderStore } from '@store/orderStore'
+import { addTaxToPrice } from '@utils/price'
 
 export class FakeSearchGateway implements SearchGateway {
   private items: Array<any> = []
@@ -89,12 +90,21 @@ export class FakeSearchGateway implements SearchGateway {
     const { field, direction } = filters.sort
     const factor = direction === 'asc' ? 1 : -1
     return [...products].sort((a: any, b: any) => {
+      const aValue = this.sortValue(a, field)
+      const bValue = this.sortValue(b, field)
       const primary =
-        typeof a[field] === 'number' && typeof b[field] === 'number'
-          ? (a[field] - b[field]) * factor
-          : String(a[field]).localeCompare(String(b[field])) * factor
+        typeof aValue === 'number' && typeof bValue === 'number'
+          ? (aValue - bValue) * factor
+          : String(aValue).localeCompare(String(bValue)) * factor
       return primary !== 0 ? primary : a.uuid.localeCompare(b.uuid)
     })
+  }
+
+  private sortValue(product: any, field: string): unknown {
+    if (field === 'priceWithTax') {
+      return addTaxToPrice(product.priceWithoutTax, product.percentTaxRate)
+    }
+    return product[field]
   }
 
   indexProducts(limit: number, offset: number): Promise<number> {

--- a/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
@@ -57,11 +57,13 @@ export class FakeSearchGateway implements SearchGateway {
       if (filters.status) {
         return p.status === filters.status
       }
+      return true
     })
-    const total = filtered.length
+    const sorted = this.sortProducts(filtered, filters)
+    const total = sorted.length
     const from = filters.from ?? 0
     const size = filters.size ?? 25
-    const items = filtered.slice(from, from + size)
+    const items = sorted.slice(from, from + size)
     const page = Math.floor(from / size) + 1
     const totalPages = Math.ceil(total / size)
     const hasMore = items.length === size && total > from + size
@@ -74,6 +76,24 @@ export class FakeSearchGateway implements SearchGateway {
         totalPages
       },
       hasMore
+    })
+  }
+
+  private sortProducts(
+    products: Array<Product>,
+    filters: SearchProductsFilters
+  ): Array<Product> {
+    if (!filters.sort) {
+      return products
+    }
+    const { field, direction } = filters.sort
+    const factor = direction === 'asc' ? 1 : -1
+    return [...products].sort((a: any, b: any) => {
+      const primary =
+        typeof a[field] === 'number' && typeof b[field] === 'number'
+          ? (a[field] - b[field]) * factor
+          : String(a[field]).localeCompare(String(b[field])) * factor
+      return primary !== 0 ? primary : a.uuid.localeCompare(b.uuid)
     })
   }
 

--- a/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
@@ -18,7 +18,10 @@ import {
   SearchOrdersDTO,
   TotalTtcCondition
 } from '@core/usecases/order/orders-searching/searchOrders'
-import { SearchProductsFilters } from '@core/usecases/product/product-searching/searchProducts'
+import {
+  PriceTtcCondition,
+  SearchProductsFilters
+} from '@core/usecases/product/product-searching/searchProducts'
 import { useCustomerStore } from '@store/customerStore'
 import { useOrderStore } from '@store/orderStore'
 import { addTaxToPrice } from '@utils/price'
@@ -38,27 +41,14 @@ export class FakeSearchGateway implements SearchGateway {
   ): Promise<SearchProductsResult> {
     const products = this.items.filter((i) => isProduct(i))
     const filtered = products.filter((p) => {
-      if (filters.query) {
-        const query = filters.query
-        const isCategoryNameMatching = p.categories.some((c) =>
-          c.name.includesWithoutCase(query)
-        )
-        const isNameMatching = p.name.includesWithoutCase(query)
-        const isLaboratoryMatching = p.laboratory
-          ? p.laboratory.name.includesWithoutCase(query)
-          : false
-        const isCip13Matching = p.cip13.includes(query)
-        return (
-          isNameMatching ||
-          isLaboratoryMatching ||
-          isCategoryNameMatching ||
-          isCip13Matching
-        )
-      }
-      if (filters.status) {
-        return p.status === filters.status
-      }
-      return true
+      const queryMatch = filters.query
+        ? this.productQueryMatch(p, filters.query)
+        : true
+      const statusMatch = filters.status ? p.status === filters.status : true
+      const priceTtcMatch = filters.priceTtcConditions?.length
+        ? this.productPriceTtcMatch(p, filters.priceTtcConditions)
+        : true
+      return queryMatch && statusMatch && priceTtcMatch
     })
     const sorted = this.sortProducts(filtered, filters)
     const total = sorted.length
@@ -77,6 +67,38 @@ export class FakeSearchGateway implements SearchGateway {
         totalPages
       },
       hasMore
+    })
+  }
+
+  private productQueryMatch = (product: any, query: string): boolean => {
+    const isCategoryNameMatching = product.categories.some((c: any) =>
+      c.name.includesWithoutCase(query)
+    )
+    const isNameMatching = product.name.includesWithoutCase(query)
+    const isLaboratoryMatching = product.laboratory
+      ? product.laboratory.name.includesWithoutCase(query)
+      : false
+    const isCip13Matching = product.cip13.includes(query)
+    return (
+      isNameMatching ||
+      isLaboratoryMatching ||
+      isCategoryNameMatching ||
+      isCip13Matching
+    )
+  }
+
+  private productPriceTtcMatch = (
+    product: any,
+    conditions: Array<PriceTtcCondition>
+  ): boolean => {
+    const priceWithTax = addTaxToPrice(
+      product.priceWithoutTax,
+      product.percentTaxRate
+    )
+    return conditions.every(({ operator, value }) => {
+      if (operator === 'lte') return priceWithTax <= value
+      if (operator === 'gte') return priceWithTax >= value
+      return Math.abs(priceWithTax - value) < 1
     })
   }
 

--- a/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/FakeSearchGateway.ts
@@ -4,6 +4,7 @@ import {
   SearchProductsResult
 } from '@core/gateways/searchGateway'
 import '@utils/strings'
+import { computeTotalWithTaxForOrder } from '@adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM'
 import { Customer } from '@core/entities/customer'
 import {
   getDeliveryStatus,
@@ -13,7 +14,10 @@ import {
 } from '@core/entities/order'
 import { Timestamp } from '@core/types/types'
 import { SearchCustomersDTO } from '@core/usecases/customers/customer-searching/searchCustomer'
-import { SearchOrdersDTO } from '@core/usecases/order/orders-searching/searchOrders'
+import {
+  SearchOrdersDTO,
+  TotalTtcCondition
+} from '@core/usecases/order/orders-searching/searchOrders'
 import { SearchProductsFilters } from '@core/usecases/product/product-searching/searchProducts'
 import { useCustomerStore } from '@store/customerStore'
 import { useOrderStore } from '@store/orderStore'
@@ -103,13 +107,17 @@ export class FakeSearchGateway implements SearchGateway {
         dto.customerUuid !== undefined
           ? dto.customerUuid === o.customerUuid
           : true
+      const totalTtcMatch = dto.totalTtcConditions?.length
+        ? this.ordersTotalTtcMatch(o, dto.totalTtcConditions)
+        : true
       return (
         queryMatch &&
         dateMatch &&
         orderStatusMatch &&
         deliveryStatusMatch &&
         paymentStatusMatch &&
-        customerUuidMatch
+        customerUuidMatch &&
+        totalTtcMatch
       )
     })
     const from = dto.from ?? 0
@@ -127,6 +135,18 @@ export class FakeSearchGateway implements SearchGateway {
       : (order.deliveries?.[0]?.receiver?.contact?.email ?? '')
     const isEmailMatching = email ? email.includesWithoutCase(query) : false
     return isReferenceMatching || isClientNameMatching || isEmailMatching
+  }
+
+  private ordersTotalTtcMatch = (
+    order: Order,
+    conditions: Array<TotalTtcCondition>
+  ): boolean => {
+    const total = computeTotalWithTaxForOrder(order)
+    return conditions.every(({ operator, value }) => {
+      if (operator === 'lte') return total <= value
+      if (operator === 'gte') return total >= value
+      return Math.abs(total - value) < 1
+    })
   }
 
   private ordersDateMatch = (

--- a/src/adapters/secondary/search-gateways/RealSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/RealSearchGateway.ts
@@ -85,6 +85,7 @@ export class RealSearchGateway extends RealGateway implements SearchGateway {
         dto.deliveryStatus !== undefined
           ? deliveryStatusMap[dto.deliveryStatus]
           : undefined,
+      totalTtcConditions: dto.totalTtcConditions,
       limit: dto.size,
       offset: dto.from
     }

--- a/src/adapters/secondary/search-gateways/RealSearchGateway.ts
+++ b/src/adapters/secondary/search-gateways/RealSearchGateway.ts
@@ -8,7 +8,6 @@ import {
   OrderLineStatus,
   PaymentStatus
 } from '@core/entities/order'
-import { Product } from '@core/entities/product'
 import {
   SearchGateway,
   SearchProductsResult
@@ -30,9 +29,7 @@ export class RealSearchGateway extends RealGateway implements SearchGateway {
       `${this.baseUrl}/search/products`,
       filters
     )
-    const items = res.data.items.sort(
-      (a: Product, b: Product) => b.availableStock - a.availableStock
-    )
+    const items = res.data.items
     const pagination = res.data.pagination
     const size = filters.size ?? 25
     const from = filters.from ?? 0

--- a/src/core/errors/CarrierLabelError.ts
+++ b/src/core/errors/CarrierLabelError.ts
@@ -1,0 +1,17 @@
+export type CarrierName = 'colissimo' | 'dpd'
+
+export interface CarrierErrorDetail {
+  carrier: CarrierName
+  errorId: string | null
+  rawMessage: string
+}
+
+export class CarrierLabelError extends Error {
+  constructor(public readonly detail: CarrierErrorDetail | null) {
+    super(
+      detail
+        ? `Carrier ${detail.carrier} error${detail.errorId ? ` (${detail.errorId})` : ''}: ${detail.rawMessage}`
+        : 'Carrier error (unparseable)'
+    )
+  }
+}

--- a/src/core/usecases/order/orders-searching/searchOrders.spec.ts
+++ b/src/core/usecases/order/orders-searching/searchOrders.spec.ts
@@ -1,3 +1,4 @@
+import { computeTotalWithTaxForOrder } from '@adapters/primary/view-models/preparations/get-orders-to-prepare/getPreparationsVM'
 import { FakeSearchGateway } from '@adapters/secondary/search-gateways/FakeSearchGateway'
 import { DeliveryStatus } from '@core/entities/delivery'
 import { Order, OrderLineStatus, PaymentStatus } from '@core/entities/order'
@@ -225,6 +226,77 @@ describe('Search orders', () => {
         expectSearchResultToEqual(elodieDurandOrder2)
       })
     })
+    describe('Filter on total TTC', () => {
+      const expensiveOrder: Order = {
+        ...orderToPrepare1,
+        uuid: 'EXPENSIVE',
+        lines: [
+          {
+            ...orderToPrepare1.lines[0],
+            expectedQuantity: orderToPrepare1.lines[0].expectedQuantity + 1
+          }
+        ]
+      }
+      beforeEach(() => {
+        givenExistingOrders(orderToPrepare1, expensiveOrder)
+      })
+      it('should keep orders with total lower or equal to the value', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'lte',
+            value: computeTotalWithTaxForOrder(orderToPrepare1)
+          }
+        ]
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(orderToPrepare1)
+      })
+      it('should keep orders with total greater or equal to the value', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'gte',
+            value: computeTotalWithTaxForOrder(expensiveOrder)
+          }
+        ]
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(expensiveOrder)
+      })
+      it('should keep orders with total equal to the value', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'eq',
+            value: computeTotalWithTaxForOrder(orderToPrepare1)
+          }
+        ]
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(orderToPrepare1)
+      })
+      it('should keep orders matching all conditions combined (between)', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'gte',
+            value: computeTotalWithTaxForOrder(orderToPrepare1)
+          },
+          {
+            operator: 'lte',
+            value: computeTotalWithTaxForOrder(expensiveOrder) - 1
+          }
+        ]
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(orderToPrepare1)
+      })
+      it('should combine the total filter with the query filter', async () => {
+        dto.totalTtcConditions = [
+          {
+            operator: 'gte',
+            value: computeTotalWithTaxForOrder(orderToPrepare1)
+          }
+        ]
+        dto.query = orderToPrepare1.uuid
+        await whenSearchForOrders(dto)
+        expectSearchResultToEqual(orderToPrepare1)
+      })
+    })
+
     describe('Pagination', () => {
       beforeEach(() => {
         givenExistingOrders(orderToPrepare1, orderPrepared1, orderNotPayed1)

--- a/src/core/usecases/order/orders-searching/searchOrders.ts
+++ b/src/core/usecases/order/orders-searching/searchOrders.ts
@@ -9,6 +9,13 @@ export interface SearchDTO {
   minimumQueryLength?: number
 }
 
+export type TotalTtcOperator = 'lte' | 'eq' | 'gte'
+
+export interface TotalTtcCondition {
+  operator: TotalTtcOperator
+  value: number
+}
+
 export interface SearchOrdersDTO extends SearchDTO {
   startDate?: Timestamp
   endDate?: Timestamp
@@ -16,6 +23,7 @@ export interface SearchOrdersDTO extends SearchDTO {
   deliveryStatus?: DeliveryStatus
   paymentStatus?: PaymentStatus
   customerUuid?: UUID
+  totalTtcConditions?: Array<TotalTtcCondition>
   size?: number
   from?: number
 }

--- a/src/core/usecases/product/product-searching/searchProducts.spec.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.spec.ts
@@ -254,6 +254,25 @@ describe('Search products', () => {
         })
       })
     })
+    describe('Sort filter', () => {
+      beforeEach(() => {
+        searchGateway.feedWith(dolodent, chamomilla, calmosine)
+      })
+      describe('Sort only, without query or status', () => {
+        beforeEach(async () => {
+          givenSortIs({ field: 'availableStock', direction: 'asc' })
+          await whenSearchForProducts()
+        })
+        it('should search the whole catalog sorted by stock', () => {
+          expectSearchResultToEqual(chamomilla, calmosine, dolodent)
+        })
+        it('should save the sort filter', () => {
+          expectCurrentFiltersToEqual({
+            sort: { field: 'availableStock', direction: 'asc' }
+          })
+        })
+      })
+    })
     describe('Status filter', () => {
       beforeEach(() => {
         searchGateway.feedWith(dolodent, ultraLevure, chamomilla)
@@ -308,6 +327,15 @@ describe('Search products', () => {
       givenQueryIs('')
       await whenSearchForProducts()
       expectLoadingToBe(false)
+    })
+
+    it('should clear previous results while a fresh search is loading', async () => {
+      givenQueryIs('cha')
+      await whenSearchForProducts()
+      givenQueryIs('dol')
+      const promise = whenSearchForProducts()
+      expectSearchResultToEqual()
+      await promise
     })
   })
 
@@ -396,6 +424,10 @@ describe('Search products', () => {
 
   const givenFromIs = (from: number) => {
     filters.from = from
+  }
+
+  const givenSortIs = (sort: SearchProductsFilters['sort']) => {
+    filters.sort = sort
   }
 
   const whenSearchForProducts = async () => {

--- a/src/core/usecases/product/product-searching/searchProducts.spec.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.spec.ts
@@ -1,10 +1,12 @@
 import { FakeSearchGateway } from '@adapters/secondary/search-gateways/FakeSearchGateway'
-import { ProductStatus } from '@core/entities/product'
+import { Product, ProductStatus } from '@core/entities/product'
 import {
+  PriceTtcCondition,
   SearchProductsFilters,
   searchProducts
 } from '@core/usecases/product/product-searching/searchProducts'
 import { useSearchStore } from '@store/searchStore'
+import { addTaxToPrice } from '@utils/price'
 import { baby, dents } from '@utils/testData/categories'
 import {
   calmosine,
@@ -15,6 +17,9 @@ import {
   ultraLevure
 } from '@utils/testData/products'
 import { createPinia, setActivePinia } from 'pinia'
+
+const ttc = (product: Product): number =>
+  addTaxToPrice(product.priceWithoutTax, product.percentTaxRate)
 
 describe('Search products', () => {
   let searchStore: any
@@ -320,6 +325,40 @@ describe('Search products', () => {
         })
       })
     })
+    describe('Price TTC conditions filter', () => {
+      beforeEach(() => {
+        searchGateway.feedWith(dolodent, chamomilla, calmosine)
+      })
+      it('should get the products with price lower than or equal', async () => {
+        givenPriceTtcConditionsAre({ operator: 'lte', value: ttc(chamomilla) })
+        await whenSearchForProducts()
+        expectSearchResultToEqual(dolodent, chamomilla)
+      })
+      it('should get the products with price greater than or equal', async () => {
+        givenPriceTtcConditionsAre({ operator: 'gte', value: ttc(chamomilla) })
+        await whenSearchForProducts()
+        expectSearchResultToEqual(chamomilla, calmosine)
+      })
+      it('should get the products with price equal', async () => {
+        givenPriceTtcConditionsAre({ operator: 'eq', value: ttc(calmosine) })
+        await whenSearchForProducts()
+        expectSearchResultToEqual(calmosine)
+      })
+      it('should combine conditions with AND to get a price range', async () => {
+        givenPriceTtcConditionsAre(
+          { operator: 'gte', value: ttc(dolodent) },
+          { operator: 'lte', value: ttc(chamomilla) }
+        )
+        await whenSearchForProducts()
+        expectSearchResultToEqual(dolodent, chamomilla)
+      })
+      it('should combine the price condition with the query filter', async () => {
+        givenQueryIs('mo')
+        givenPriceTtcConditionsAre({ operator: 'gte', value: ttc(calmosine) })
+        await whenSearchForProducts()
+        expectSearchResultToEqual(calmosine)
+      })
+    })
   })
 
   describe('Loading state', () => {
@@ -436,6 +475,12 @@ describe('Search products', () => {
 
   const givenStatusFilterIs = (status: ProductStatus) => {
     filters.status = status
+  }
+
+  const givenPriceTtcConditionsAre = (
+    ...conditions: Array<PriceTtcCondition>
+  ) => {
+    filters.priceTtcConditions = conditions
   }
 
   const givenMinimumQueryLength = (length: number) => {

--- a/src/core/usecases/product/product-searching/searchProducts.spec.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.spec.ts
@@ -272,6 +272,30 @@ describe('Search products', () => {
           })
         })
       })
+      describe('Sort by priceWithoutTax', () => {
+        it('should sort the whole catalog by price HT ascending', async () => {
+          givenSortIs({ field: 'priceWithoutTax', direction: 'asc' })
+          await whenSearchForProducts()
+          expectSearchResultToEqual(dolodent, chamomilla, calmosine)
+        })
+        it('should sort the whole catalog by price HT descending', async () => {
+          givenSortIs({ field: 'priceWithoutTax', direction: 'desc' })
+          await whenSearchForProducts()
+          expectSearchResultToEqual(calmosine, chamomilla, dolodent)
+        })
+      })
+      describe('Sort by priceWithTax', () => {
+        it('should sort the whole catalog by price TTC ascending', async () => {
+          givenSortIs({ field: 'priceWithTax', direction: 'asc' })
+          await whenSearchForProducts()
+          expectSearchResultToEqual(dolodent, chamomilla, calmosine)
+        })
+        it('should sort the whole catalog by price TTC descending', async () => {
+          givenSortIs({ field: 'priceWithTax', direction: 'desc' })
+          await whenSearchForProducts()
+          expectSearchResultToEqual(calmosine, chamomilla, dolodent)
+        })
+      })
     })
     describe('Status filter', () => {
       beforeEach(() => {

--- a/src/core/usecases/product/product-searching/searchProducts.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.ts
@@ -2,12 +2,18 @@ import { ProductStatus } from '@core/entities/product'
 import { SearchGateway } from '@core/gateways/searchGateway'
 import { useSearchStore } from '@store/searchStore'
 
+export interface ProductsSort {
+  field: string
+  direction: 'asc' | 'desc'
+}
+
 export interface SearchProductsFilters {
   query?: string
   minimumQueryLength?: number
   status?: ProductStatus
   size?: number
   from?: number
+  sort?: ProductsSort
 }
 
 export const searchProducts = async (
@@ -26,14 +32,17 @@ export const searchProducts = async (
     searchStore.set(key, [])
     searchStore.setPagination(key, { total: 0, from: 0, hasMore: false })
     searchStore.endLoading(key)
-  } else if (!filters.query && !filters.status) {
+  } else if (!filters.query && !filters.status && !filters.sort) {
     searchStore.clear(key)
     searchStore.setError(key, undefined)
     searchStore.endLoading(key)
   } else {
     searchStore.startLoading(key)
-    const searchResult = await searchGateway.searchProducts(filters)
     const isAppending = (filters.from ?? 0) > 0
+    if (!isAppending) {
+      searchStore.set(key, [])
+    }
+    const searchResult = await searchGateway.searchProducts(filters)
     if (isAppending) {
       searchStore.append(key, searchResult.items)
     } else {

--- a/src/core/usecases/product/product-searching/searchProducts.ts
+++ b/src/core/usecases/product/product-searching/searchProducts.ts
@@ -1,5 +1,6 @@
 import { ProductStatus } from '@core/entities/product'
 import { SearchGateway } from '@core/gateways/searchGateway'
+import { PriceFilterOperator } from '@core/usecases/shared/priceFilter'
 import { useSearchStore } from '@store/searchStore'
 
 export interface ProductsSort {
@@ -7,10 +8,16 @@ export interface ProductsSort {
   direction: 'asc' | 'desc'
 }
 
+export interface PriceTtcCondition {
+  operator: PriceFilterOperator
+  value: number
+}
+
 export interface SearchProductsFilters {
   query?: string
   minimumQueryLength?: number
   status?: ProductStatus
+  priceTtcConditions?: Array<PriceTtcCondition>
   size?: number
   from?: number
   sort?: ProductsSort
@@ -32,7 +39,12 @@ export const searchProducts = async (
     searchStore.set(key, [])
     searchStore.setPagination(key, { total: 0, from: 0, hasMore: false })
     searchStore.endLoading(key)
-  } else if (!filters.query && !filters.status && !filters.sort) {
+  } else if (
+    !filters.query &&
+    !filters.status &&
+    !filters.sort &&
+    !filters.priceTtcConditions?.length
+  ) {
     searchStore.clear(key)
     searchStore.setError(key, undefined)
     searchStore.endLoading(key)

--- a/src/core/usecases/shared/priceFilter.ts
+++ b/src/core/usecases/shared/priceFilter.ts
@@ -1,0 +1,1 @@
+export type PriceFilterOperator = 'lte' | 'eq' | 'gte'


### PR DESCRIPTION
Related: phardev/ecommerce#153 — paired with phardev/ecommerce-backend PR (same branch name).

## Summary
- Catches the new structured `{ message, carrierError }` 500 response from the backend in `realDeliveryGateway` (handles both JSON and Blob bodies for `downloadLabel`) and rethrows a typed `CarrierLabelError`.
- Order detail page surfaces the error as a persistent `UAlert` stack **below** the deliveries table, full width, prefixed by `<méthode> · <client>` to identify the row. Replaces the old inline `text-red-600` for `generateLabel` and the silent `console.error` for `downloadLabel` / no-op for `printLabel`.
- FR mapping for the two real-world cases the pharmacist will see (`ShopIsOnHoliday`, `UnknownZipCodeCity`); unmapped errors fall back to `Le transporteur a refusé la demande : <raw>`; unparseable → generic message.
- French typography: non-breaking space before `:`.

## Dependency
The actual carrier reason only reaches the frontend once the matching DPD submodule patch is deployed (PR on `phardev/dpd@main`). Until then the generic fallback message is displayed — no UX regression.

## Test plan
- [x] `pnpm vue-tsc --noEmit` — zero errors
- [x] `pnpm lint` (Biome) — zero errors
- [x] `pnpm test run` — 2452/2452 passing
- [x] Manual e2e against a local DPD module: `Permission denied` SOAP fault propagates end-to-end and renders as "Le transporteur a refusé la demande : Permission denied" with the delivery prefix
- [ ] After DPD module deploy: smoke-test on a real failing address to confirm `UnknownZipCodeCity` → "Adresse invalide : code postal / ville inconnus."

🤖 Generated with [Claude Code](https://claude.com/claude-code)